### PR TITLE
Move jacket blurbs inline under back cover

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "subtitle-generator"
-version = "0.1.0"
+version = "0.2.0"
 description = "Generate bizarre book subtitles by mixing real parts from Library of Congress MARC records"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/subtitle_generator/jacket.py
+++ b/src/subtitle_generator/jacket.py
@@ -25,11 +25,13 @@ REQUIRED_SECTIONS = [
     "## Back Cover",
     "## Review 1",
     "## Review 2",
-    "## Blurb 1",
-    "## Blurb 2",
 ]
 
 MAX_RETRIES = 2
+
+INLINE_BLURB_RE = re.compile(
+    r'(?m)^\s*["“][^"“”\n]+["”]\s+—\s+[^,\n]+,\s+.+$'
+)
 
 # --- Accessibility scoring & tone tiers ---
 
@@ -182,6 +184,16 @@ The publisher's marketing copy for the back of the book. 2-3 paragraphs (~250 wo
 Open with a hook question or provocative claim. End with an emotional/intellectual payoff.
 Tone: urgent, seductive, intellectually intriguing.
 
+Immediately below the back cover copy, include exactly TWO endorsement blurbs as separate
+paragraphs before the Review 1 header. Do NOT create separate blurb headers or blockquotes.
+For each blurb, use web_search to find a real person (author, academic, journalist, public
+intellectual) or real publication whose expertise aligns with this book's subject matter,
+then search for examples of their actual writing or past blurbs to understand their
+distinctive voice. At least one blurb must be from a real individual person. Format each
+blurb exactly like this:
+
+"[A single compelling endorsement sentence written in their authentic voice and style]" — [Full Name], [brief credential, e.g. author of The Looming Tower]
+
 ## Review 1
 Pick the most appropriate trade publication for this book from the roster below. Write
 the review in that publication's AUTHENTIC house style — match their real tone, vocabulary,
@@ -224,21 +236,6 @@ Format:
 ## Review 2
 Pick a second- or third-most appropriate publication from the roster above. Same approach — write in THEIR
 authentic house style with their specific format conventions.
-
-## Blurb 1
-Use web_search to find a real person (author, academic, journalist, public intellectual)
-whose expertise aligns with this book's subject matter. Then search for examples of their
-actual writing or past blurbs to understand their distinctive voice — their vocabulary,
-sentence rhythm, rhetorical habits, and tone. The blurb should sound like THEM, not like
-generic marketing copy. Format:
-
-**[Full Name]** ([brief credential, e.g. "author of The Looming Tower"])
-> "[A single compelling endorsement sentence written in their authentic voice and style]"
-
-## Blurb 2
-Find a SECOND real person (or a real publication/newspaper that covers this topic).
-Same approach — web_search for their writing style, then compose the blurb in their voice.
-At least one of the two blurbs must be from a real individual person.
 
 ---
 
@@ -288,14 +285,36 @@ def build_jacket_prompt(
 
 
 def _validate_jacket(content: str) -> list[str]:
-    """Check that all required sections are present. Returns list of missing section names."""
+    """Check required section headers and inline back-cover blurbs.
+
+    Returns a list of missing or invalid format requirements.
+    """
     missing = []
     for section in REQUIRED_SECTIONS:
         # Case-insensitive header check (model may vary casing)
         pattern = re.compile(re.escape(section), re.IGNORECASE)
         if not pattern.search(content):
             missing.append(section)
+    if "## Back Cover" not in missing:
+        back_cover = _extract_section(content, "## Back Cover")
+        inline_blurbs = list(INLINE_BLURB_RE.finditer(back_cover))
+        if len(inline_blurbs) != 2:
+            missing.append("exactly two inline Back Cover blurbs")
+        elif not back_cover[:inline_blurbs[0].start()].strip():
+            missing.append("Back Cover description before inline blurbs")
+    if re.search(r"^##\s+Blurb\s+\d+\s*$", content, re.IGNORECASE | re.MULTILINE):
+        missing.append("remove separate ## Blurb sections")
     return missing
+
+
+def _extract_section(content: str, section: str) -> str:
+    """Return the body for a markdown H2 section, or an empty string if absent."""
+    pattern = re.compile(
+        rf"^\s*{re.escape(section)}\s*\n(?P<body>.*?)(?=^\s*##\s+|\Z)",
+        re.IGNORECASE | re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(content)
+    return match.group("body") if match else ""
 
 
 DEFAULT_MODEL = "gpt-5.4-mini"
@@ -356,10 +375,14 @@ async def _generate_jacket_async(
 
                 if attempt <= MAX_RETRIES:
                     missing_names = ", ".join(missing)
-                    _progress(f"Attempt {attempt}: missing {missing_names}, retrying...")
+                    _progress(f"Attempt {attempt}: format issues: {missing_names}, retrying...")
                     prompt = (
-                        f"Your previous response was missing these required sections: {missing_names}.\n"
-                        f"Please regenerate the COMPLETE book jacket with ALL sections. "
+                        f"Your previous response did not satisfy these required sections "
+                        f"or format requirements: {missing_names}.\n"
+                        f"Please regenerate the COMPLETE book jacket with ALL sections and "
+                        f"place the two endorsement blurbs inline inside the Back Cover section, "
+                        f"directly below the description and before Review 1. Do not use separate "
+                        f"## Blurb sections. "
                         f"The subtitle is:\n\n{subtitle}"
                     )
                 else:

--- a/tests/test_jacket.py
+++ b/tests/test_jacket.py
@@ -1,0 +1,123 @@
+"""Tests for jacket prompt and validation formatting.
+
+Run:  uv run python tests/test_jacket.py
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from subtitle_generator.jacket import (  # noqa: E402
+    JACKET_PROMPT,
+    _strip_internal_concept,
+    _validate_jacket,
+    build_jacket_prompt,
+)
+
+
+def _valid_inline_jacket() -> str:
+    return """## Title
+Bright Ruins
+
+## Subtitle
+Faith, Commerce, and the Making of Modern Appetite
+
+## Internal Concept
+This is the private planning section.
+
+## Back Cover
+What do our hungers reveal about the lives we think we are choosing? This book follows
+the marketplaces, rituals, and private compromises that turn desire into destiny.
+
+"A sharp and unsettling map of the bargains hiding inside ordinary appetite." — Ross Douthat, New York Times columnist
+
+"This bracing book sees what so much of public life tries to hide." — Rod Dreher, author of The Benedict Option
+
+## Review 1
+**Publishers Weekly**
+A polished review.
+
+## Review 2
+**Kirkus Reviews**
+A pointed review.
+"""
+
+
+def test_prompt_places_blurbs_inside_back_cover():
+    assert "## Blurb 1" not in JACKET_PROMPT
+    assert "## Blurb 2" not in JACKET_PROMPT
+
+    system_prompt, user_prompt, _ = build_jacket_prompt(
+        "Faith, Commerce, and the Making of Modern Appetite"
+    )
+    assert "include exactly TWO endorsement blurbs" in system_prompt
+    assert '"[A single compelling endorsement sentence' in system_prompt
+    assert "Do NOT create separate blurb headers" in system_prompt
+    assert "## Review 1" in system_prompt
+    assert "The subtitle is:" in user_prompt
+
+
+def test_validate_accepts_inline_back_cover_blurbs():
+    assert _validate_jacket(_valid_inline_jacket()) == []
+
+
+def test_validate_rejects_separate_blurb_sections():
+    content = _valid_inline_jacket() + """
+## Blurb 1
+**Someone** (credential)
+> "A standalone blurb."
+"""
+    assert "remove separate ## Blurb sections" in _validate_jacket(content)
+
+
+def test_validate_requires_two_inline_blurbs_in_back_cover():
+    content = _valid_inline_jacket().replace(
+        '"This bracing book sees what so much of public life tries to hide." — Rod Dreher, author of The Benedict Option',
+        "",
+    )
+    assert "exactly two inline Back Cover blurbs" in _validate_jacket(content)
+
+
+def test_validate_rejects_extra_inline_blurbs():
+    content = _valid_inline_jacket().replace(
+        "## Review 1",
+        '"A third blurb is one too many." — Jane Critic, critic at Large\n\n## Review 1',
+    )
+    assert "exactly two inline Back Cover blurbs" in _validate_jacket(content)
+
+
+def test_validate_requires_description_before_inline_blurbs():
+    content = _valid_inline_jacket().replace(
+        """What do our hungers reveal about the lives we think we are choosing? This book follows
+the marketplaces, rituals, and private compromises that turn desire into destiny.
+
+""",
+        "",
+    )
+    assert "Back Cover description before inline blurbs" in _validate_jacket(content)
+
+
+def test_strip_internal_concept_preserves_inline_blurbs():
+    stripped = _strip_internal_concept(_valid_inline_jacket())
+    assert "## Internal Concept" not in stripped
+    assert "## Back Cover" in stripped
+    assert "Ross Douthat" in stripped
+    assert "Rod Dreher" in stripped
+    assert "## Review 1" in stripped
+
+
+if __name__ == "__main__":
+    tests = [
+        test_prompt_places_blurbs_inside_back_cover,
+        test_validate_accepts_inline_back_cover_blurbs,
+        test_validate_rejects_separate_blurb_sections,
+        test_validate_requires_two_inline_blurbs_in_back_cover,
+        test_validate_rejects_extra_inline_blurbs,
+        test_validate_requires_description_before_inline_blurbs,
+        test_strip_internal_concept_preserves_inline_blurbs,
+    ]
+    for test in tests:
+        test()
+        print(f"  PASS: {test.__name__}")
+    print("All jacket tests passed.")

--- a/uv.lock
+++ b/uv.lock
@@ -1662,7 +1662,7 @@ wheels = [
 
 [[package]]
 name = "subtitle-generator"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #3.

## Summary
- Move jacket endorsement blurb instructions into the Back Cover section instead of standalone Blurb sections.
- Update jacket validation to require exactly two inline Back Cover blurbs after description text and reject separate ## Blurb sections.
- Add focused jacket prompt/validation tests and bump package version to 0.2.0.

## Validation
- uv run python tests\test_jacket.py
- uv run python tests\test_articles.py
- git --no-pager diff --check

## Notes
- Multi-model review found validation gaps around exact blurb count and ordering; fixed before commit.
- uv run pytest is not currently a valid repo-wide check because script-style e2e tests execute during collection without a running localhost server.