### PR TITLE
Add feedback tags and mobile spacing

### DIFF
--- a/src/subtitle_generator/cli.py
+++ b/src/subtitle_generator/cli.py
@@ -39,7 +39,14 @@ def _get_system_tone(subtitle: str, conn) -> tuple[str, float]:
     return "niche", score
 
 
-_TAG_MAP = {"f": "funny", "b": "boring", "r": "broken", "n": "nonsense"}
+_TAG_MAP = {
+    "f": "funny",
+    "b": "boring",
+    "r": "broken",
+    "n": "nonsense",
+    "l": "realistic",
+    "i": "interesting",
+}
 
 
 def _prompt_review(conn, subtitle_text: str) -> int | None:
@@ -72,7 +79,7 @@ def _prompt_review(conn, subtitle_text: str) -> int | None:
 
     # Tags
     tags_input = click.prompt(
-        click.style("     Tags? [f=funny / b=boring / r=broken / n=nonsense / Enter]", fg="cyan"),
+        click.style("     Tags? [f=funny / b=boring / r=broken / n=nonsense / l=realistic / i=interesting / Enter]", fg="cyan"),
         default="", show_default=False,
     ).strip().lower()
     tags = [_TAG_MAP[c] for c in tags_input if c in _TAG_MAP] or None

--- a/src/subtitle_generator/feedback.py
+++ b/src/subtitle_generator/feedback.py
@@ -16,6 +16,15 @@ from pydantic import BaseModel
 
 from subtitle_generator.config import load_tuning_config
 
+VALID_RATING_TAGS = frozenset({
+    "funny",
+    "boring",
+    "broken",
+    "nonsense",
+    "realistic",
+    "interesting",
+})
+
 # ---------------------------------------------------------------------------
 # Pydantic schemas
 # ---------------------------------------------------------------------------
@@ -83,7 +92,7 @@ def store_rating(
         thumbs: 1 = good, -1 = bad, None = skipped.
         tone_override: What the human thinks the tone should be (p/m/n).
         free_text: Optional free-text comment.
-        tags: Quality tags like ["funny", "grammar", "contradiction", "boring"].
+        tags: Quality tags like ["interesting", "realistic", "funny", "boring"].
         source: Origin of this rating ("spot_check", "web_user", "pull_ratings").
     """
     ensure_ratings_table(conn)

--- a/src/subtitle_generator/handlers.py
+++ b/src/subtitle_generator/handlers.py
@@ -225,8 +225,9 @@ def handle_rate(body: dict) -> tuple[int, dict]:
     if tags is not None:
         if not isinstance(tags, list) or not all(isinstance(t, str) for t in tags):
             return 400, {"error": "tags must be an array of strings"}
-        valid_tags = {"funny", "boring", "broken", "nonsense"}
-        invalid_tags = set(tags) - valid_tags
+        from subtitle_generator.feedback import VALID_RATING_TAGS
+
+        invalid_tags = set(tags) - VALID_RATING_TAGS
         if invalid_tags:
             return 400, {"error": f"Invalid tags: {', '.join(invalid_tags)}"}
 

--- a/src/subtitle_generator/serve.py
+++ b/src/subtitle_generator/serve.py
@@ -188,8 +188,9 @@ def _handle_spot_check_rate(body: dict) -> tuple[int, dict]:
     if tags is not None:
         if not isinstance(tags, list) or not all(isinstance(t, str) for t in tags):
             return 400, {"error": "tags must be an array of strings"}
-        valid_tags = {"funny", "grammar", "contradiction", "boring"}
-        invalid_tags = set(tags) - valid_tags
+        from subtitle_generator.feedback import VALID_RATING_TAGS
+
+        invalid_tags = set(tags) - VALID_RATING_TAGS
         if invalid_tags:
             return 400, {"error": f"Invalid tags: {', '.join(invalid_tags)}"}
 

--- a/src/subtitle_generator/tune.py
+++ b/src/subtitle_generator/tune.py
@@ -786,10 +786,17 @@ def _spot_check_cli(
                 ))
 
             tags_input = click.prompt(
-                click.style("       Tags? [f=funny/b=boring/r=broken/n=nonsense / Enter]", fg="cyan"),
+                click.style("       Tags? [f=funny/b=boring/r=broken/n=nonsense/l=realistic/i=interesting / Enter]", fg="cyan"),
                 default="", show_default=False,
             ).strip().lower()
-            tag_map = {"f": "funny", "b": "boring", "r": "broken", "n": "nonsense"}
+            tag_map = {
+                "f": "funny",
+                "b": "boring",
+                "r": "broken",
+                "n": "nonsense",
+                "l": "realistic",
+                "i": "interesting",
+            }
             tags = [tag_map[c] for c in tags_input if c in tag_map] or None
 
             store_rating(

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -110,8 +110,18 @@ async def test():
         print(f"  Slots ({slots}): {slot_texts}")
         print("  PASS: subtitle generated")
 
+        print("TEST 3b: Rating quality tags")
+        interesting_btn = page.locator('[data-testid="tag-interesting"]')
+        realistic_btn = page.locator('[data-testid="tag-realistic"]')
+        assert await interesting_btn.is_visible(), "Interesting tag should be visible"
+        assert await realistic_btn.is_visible(), "Realistic tag should be visible"
+        await interesting_btn.click()
+        interesting_class = await interesting_btn.get_attribute("class")
+        assert "active" in interesting_class, f"Expected Interesting tag active, got: {interesting_class}"
+        print("  PASS: realistic/interesting tags visible and toggle")
+
         if not is_local:
-            print("TEST 3b: App Insights generate telemetry")
+            print("TEST 3c: App Insights generate telemetry")
             await wait_for_telemetry(
                 lambda: any(
                     "GenerateSuccess" in post or "GenerateDuration" in post
@@ -213,8 +223,18 @@ async def test():
         assert got_remix, "No remix after 30 attempts (remix_prob=0.8, expected ~80%)"
         print("  PASS: remix sub-parts rendered")
 
+        # 11. Mobile layout should not create horizontal overflow
+        print("TEST 11: Mobile spacing")
+        await page.set_viewport_size({"width": 390, "height": 844})
+        await page.wait_for_timeout(500)
+        has_horizontal_overflow = await page.evaluate(
+            "() => document.documentElement.scrollWidth > window.innerWidth"
+        )
+        assert not has_horizontal_overflow, "Mobile layout should not horizontally overflow"
+        print("  PASS: mobile layout stays within viewport")
+
         print()
-        print(f"ALL 10 TESTS PASSED ({BASE_URL})")
+        print(f"ALL 11 TESTS PASSED ({BASE_URL})")
         await browser.close()
 
 

--- a/tests/test_e2e_spot_check.py
+++ b/tests/test_e2e_spot_check.py
@@ -110,6 +110,14 @@ async def test():
         assert "active" not in funny_class, f"Expected funny tag inactive after toggle"
         # Toggle on again for the submission
         await page.locator('[data-testid="tag-funny"]').click()
+        await page.keyboard.press("i")
+        interesting_btn = page.locator('[data-testid="tag-interesting"]')
+        interesting_class = await interesting_btn.get_attribute("class")
+        assert "active" in interesting_class, f"Expected interesting tag active, got class: {interesting_class}"
+        await page.keyboard.press("l")
+        realistic_btn = page.locator('[data-testid="tag-realistic"]')
+        realistic_class = await realistic_btn.get_attribute("class")
+        assert "active" in realistic_class, f"Expected realistic tag active, got class: {realistic_class}"
         print(f"  PASS: tags toggle correctly")
 
         # Advance to next

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -11,6 +11,7 @@ import json
 import random
 import sqlite3
 import sys
+import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
@@ -54,6 +55,17 @@ def make_test_db() -> sqlite3.Connection:
     )
     conn.commit()
     return conn
+
+
+def make_test_db_file() -> str:
+    """Create a temporary SQLite DB file with the feedback test schema."""
+    path = tempfile.NamedTemporaryFile(suffix=".db", delete=False).name
+    src = make_test_db()
+    dst = sqlite3.connect(path)
+    src.backup(dst)
+    dst.close()
+    src.close()
+    return path
 
 
 class RobotGrader:
@@ -287,11 +299,11 @@ def test_cli_review_mock():
     prompt_responses = []
     for sub in subtitles:
         grade = grader.grade(sub)
-        # Simulate: thumbs prompt, tone prompt, comment prompt
+        # Simulate: thumbs prompt, tone prompt, comment prompt, tags prompt
         thumbs_str = "y" if grade["thumbs"] == 1 else "n"
         tone_str = grade["tone_override"][0]  # p, m, or n
         comment_str = grade["comment"] or ""
-        prompt_responses.extend([thumbs_str, tone_str, comment_str])
+        prompt_responses.extend([thumbs_str, tone_str, comment_str, ""])
 
     call_idx = [0]
 
@@ -352,6 +364,38 @@ def test_idempotent_table_creation():
     conn.close()
 
 
+def test_handle_rate_accepts_quality_tags():
+    """API validation accepts the full shared quality-tag set."""
+    from subtitle_generator.handlers import handle_rate
+
+    db_path = make_test_db_file()
+    with patch("subtitle_generator.handlers.get_db", side_effect=lambda: sqlite3.connect(db_path)):
+        status, body = handle_rate({
+            "subtitle": "A, B, and the C of D",
+            "tags": ["interesting", "realistic", "funny"],
+        })
+
+    assert status == 200, body
+    conn = sqlite3.connect(db_path)
+    tags_json = conn.execute("SELECT tags FROM human_ratings").fetchone()[0]
+    conn.close()
+    Path(db_path).unlink(missing_ok=True)
+    assert json.loads(tags_json) == ["interesting", "realistic", "funny"]
+
+    db_path = make_test_db_file()
+    with patch("subtitle_generator.handlers.get_db", side_effect=lambda: sqlite3.connect(db_path)):
+        status, body = handle_rate({
+            "subtitle": "A, B, and the C of D",
+            "tags": ["grammar"],
+        })
+
+    assert status == 400
+    assert "Invalid tags" in body["error"]
+    Path(db_path).unlink(missing_ok=True)
+
+    print("  PASS: handle_rate_accepts_quality_tags")
+
+
 def test_empty_summary():
     """get_summary() returns None when no ratings exist."""
     from subtitle_generator.feedback import ensure_ratings_table, get_summary
@@ -376,6 +420,7 @@ if __name__ == "__main__":
         ("robot_grader_batch", test_robot_grader_batch),
         ("cli_review_mock", test_cli_review_mock),
         ("idempotent_table_creation", test_idempotent_table_creation),
+        ("handle_rate_accepts_quality_tags", test_handle_rate_accepts_quality_tags),
         ("empty_summary", test_empty_summary),
     ]
 

--- a/web/index.html
+++ b/web/index.html
@@ -109,6 +109,25 @@ body{font-family:'Segoe UI',system-ui,sans-serif;background:#1a1a2e;color:#e0e0e
 .tag-row{gap:6px}
 .rating-reveal{font-size:11px;color:#81b29a;padding:4px 0}
 
+@media (max-width: 600px){
+  body{overflow-x:hidden}
+  .app{max-width:none;padding:12px}
+  .header{padding:12px 0;margin-bottom:14px}
+  .settings,.subtitle-display,.rating-section,.jacket-section,.prompt-section,.sources{padding:12px;margin-bottom:12px}
+  .settings-grid{grid-template-columns:1fr}
+  .subtitle-display{min-height:78px}
+  .slot-row{font-size:16px;line-height:1.65;gap:3px}
+  .slot{padding:3px 8px}
+  .slot-subpart{font-size:14px}
+  .actions{gap:7px;margin-bottom:12px}
+  .actions .btn{flex:1 1 calc(50% - 7px);min-width:0;padding:9px 10px}
+  .rating-row{align-items:stretch;flex-wrap:wrap;gap:7px}
+  .rating-label{flex:1 0 100%;min-width:0}
+  .btn-tag{flex:1 1 calc(50% - 7px);padding:7px 8px;text-align:center}
+  .jacket-actions,.prompt-actions{flex-wrap:wrap}
+  .prompt-text{max-height:220px}
+}
+
 /* Spinner */
 @keyframes spin{to{transform:rotate(360deg)}}
 .spinner{display:inline-block;width:14px;height:14px;border:2px solid #444;border-top-color:#e07a5f;border-radius:50%;animation:spin .6s linear infinite;margin-right:6px;vertical-align:middle}
@@ -196,6 +215,8 @@ body{font-family:'Segoe UI',system-ui,sans-serif;background:#1a1a2e;color:#e0e0e
   <div class="rating-section" x-show="hasSubtitle" x-cloak>
     <div class="rating-row tag-row">
       <span class="rating-label">How'd it land?</span>
+      <button class="btn-tag" :class="{ active: selectedTags.includes('interesting') }" @click="toggleTag('interesting')" data-testid="tag-interesting">✨ Interesting</button>
+      <button class="btn-tag" :class="{ active: selectedTags.includes('realistic') }" @click="toggleTag('realistic')" data-testid="tag-realistic">✅ Realistic</button>
       <button class="btn-tag" :class="{ active: selectedTags.includes('funny') }" @click="toggleTag('funny')">😂 Funny</button>
       <button class="btn-tag" :class="{ active: selectedTags.includes('boring') }" @click="toggleTag('boring')">🥱 Boring</button>
       <button class="btn-tag" :class="{ active: selectedTags.includes('broken') }" @click="toggleTag('broken')">🪦 Broken</button>

--- a/web/js/services.js
+++ b/web/js/services.js
@@ -58,6 +58,9 @@ export function createApi(baseUrl = "", fetchFn = fetch) {
       });
       const durationMs = Math.round(performance.now() - t0);
       trackMetric("JacketDuration", durationMs, { dryRun: String(dryRun), model: model || "gpt-5.4-mini" });
+      if (dryRun && !result.error) {
+        trackMetric("BuildPrompt", 1, { model: model || "gpt-5.4-mini", durationMs: String(durationMs) });
+      }
       return result;
     },
 

--- a/web/js/spot-check-app.js
+++ b/web/js/spot-check-app.js
@@ -223,6 +223,8 @@ export function spotCheckApp() {
         else if (key === "b") { this.toggleTag("boring"); event.preventDefault(); }
         else if (key === "r") { this.toggleTag("broken"); event.preventDefault(); }
         else if (key === "n") { this.toggleTag("nonsense"); event.preventDefault(); }
+        else if (key === "l") { this.toggleTag("realistic"); event.preventDefault(); }
+        else if (key === "i") { this.toggleTag("interesting"); event.preventDefault(); }
         else if (key === "enter") { this.next(); event.preventDefault(); }
       }
     },

--- a/web/spot-check.html
+++ b/web/spot-check.html
@@ -75,6 +75,16 @@ body{font-family:'Segoe UI',system-ui,sans-serif;background:#1a1a2e;color:#e0e0e
 .btn-next{padding:8px 24px;border-radius:7px;border:none;background:#e07a5f;color:#fff;font-size:13px;font-weight:600;cursor:pointer;transition:all .12s;margin-top:8px}
 .btn-next:hover{transform:translateY(-1px)}
 
+@media (max-width: 600px){
+  body{overflow-x:hidden}
+  .app{max-width:none;padding:12px}
+  .subtitle-card,.reveal-panel,.summary-panel{padding:14px;margin-bottom:12px}
+  .tier-buttons{gap:8px}
+  .btn-tier{flex:1 1 100%;min-width:0}
+  .btn-tag{flex:1 1 calc(50% - 6px);padding:7px 8px;text-align:center}
+  .btn-next{width:100%}
+}
+
 /* Summary */
 .summary-panel{background:#16213e;border:1px solid #2a2a4a;border-radius:10px;padding:20px;margin-bottom:18px}
 .summary-panel h3{font-size:14px;color:#f0f0f0;margin-bottom:12px}
@@ -213,6 +223,8 @@ body{font-family:'Segoe UI',system-ui,sans-serif;background:#1a1a2e;color:#e0e0e
         <div class="tag-section" data-testid="tag-section">
           <div class="tag-label">Quality tags (optional)</div>
           <div class="tag-buttons">
+            <button class="btn-tag" :class="{ active: currentTags.includes('interesting') }" @click="toggleTag('interesting')" data-testid="tag-interesting">✨ Interesting <kbd>I</kbd></button>
+            <button class="btn-tag" :class="{ active: currentTags.includes('realistic') }" @click="toggleTag('realistic')" data-testid="tag-realistic">✅ Realistic <kbd>L</kbd></button>
             <button class="btn-tag" :class="{ active: currentTags.includes('funny') }" @click="toggleTag('funny')" data-testid="tag-funny">😂 Funny <kbd>F</kbd></button>
             <button class="btn-tag" :class="{ active: currentTags.includes('boring') }" @click="toggleTag('boring')" data-testid="tag-boring">🥱 Boring <kbd>B</kbd></button>
             <button class="btn-tag" :class="{ active: currentTags.includes('broken') }" @click="toggleTag('broken')" data-testid="tag-broken">🪦 Broken <kbd>R</kbd></button>

--- a/web/tests/test-services.js
+++ b/web/tests/test-services.js
@@ -105,6 +105,23 @@ await test("jacket sends correct body for full generation", async () => {
   assert(capturedBody.dry_run === false, "dry_run false");
 });
 
+await test("jacket dry_run tracks BuildPrompt engagement metric", async () => {
+  const metrics = [];
+  globalThis.window = {
+    appInsights: {
+      trackMetric: (metric, props) => metrics.push({ metric, props }),
+    },
+  };
+  const api = createApi("", mockFetch(200, { prompt: "...", tone_tier: "pop", result: null }));
+  await api.jacket({ subtitle: "test subtitle", model: "gpt-4.1", dryRun: true });
+  delete globalThis.window;
+
+  assert(
+    metrics.some(m => m.metric.name === "BuildPrompt" && m.metric.average === 1),
+    "BuildPrompt metric tracked",
+  );
+});
+
 // ── baseUrl ──
 
 await test("baseUrl is prepended to paths", async () => {


### PR DESCRIPTION
## Summary

| Area | Change |
|---|---|
| Feedback UI | Adds ✨ Interesting and ✅ Realistic tags to the main generator and spot-check flows. |
| API validation | Centralizes accepted rating tags in `VALID_RATING_TAGS` and wires both deployed/local rate handlers to it. |
| Mobile UX | Adds compact responsive layout rules to prevent horizontal overflow on generator and spot-check pages. |
| Telemetry | Tracks successful Build Prompt dry-runs as a `BuildPrompt` App Insights metric. |
| Tests | Covers new tags, Build Prompt metric, backend validation, spot-check shortcuts, and mobile overflow. |

Fixes #5

## Validation

- `node web\\tests\\test-services.js`
- `uv run python tests\\test_feedback.py`
- `uv run python tests\\test_articles.py`
- Targeted mocked Playwright UI/mobile checks
- Code review agent: no blocking findings

Note: `uv run pytest` is not currently usable as a repo-wide suite because pytest collection executes browser scripts without a server and picked up a global Python 3.10 pytest environment missing project deps.