### PR TITLE
Document and validate pipeline boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ uv run subtitle-gen extract-ol                  # parse + deduplicate
 uv run subtitle-gen build-slots                 # extract slot fillers
 uv run subtitle-gen download-popularity         # SPL, Goodreads, Ottawa, etc.
 uv run subtitle-gen populate-popularity         # compute composite scores
+uv run subtitle-gen precompute-vectors          # remix scalar/vector state
 uv run subtitle-gen validate-pipeline           # read-only readiness checks
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ Celebrity Culture, Theology, and the Collapse of New England
 2. **Extract** 11M+ English subtitles into SQLite (with cross-source deduplication)
 3. **Pattern match** subtitles matching "X, Y, and [the/a/an] Z of [the/a/an] W" using regex + spaCy NLP validation
 4. **Decompose** into typed slots: list items, action nouns, of-objects — plus sub-parts (modifiers, heads, prepositional complements) for remixing. Articles (a/an/the) are stripped and stored separately for re-insertion at generation time.
-5. **Generate** by randomly drawing one filler per slot — weighted by sqrt(corpus frequency). Multi-word of-objects can be remixed into novel combinations (e.g., "New York" + "kitsch" from different books)
-6. **Jacket** (optional) — send the subtitle to an LLM (via Copilot SDK) to generate a full book jacket with trade journal reviews and endorsement blurbs from real people
+5. **Score and tune** fillers with popularity, tone, article, and remix parameters stored in SQLite config rows with Python contract views.
+6. **Generate** by randomly drawing one filler per slot — weighted by corpus frequency, popularity, and tone targets. Multi-word of-objects can be remixed into novel combinations (e.g., "New York" + "kitsch" from different books)
+7. **Jacket** (optional) — send the subtitle to an LLM (via Copilot SDK) to generate a full book jacket with trade journal reviews and endorsement blurbs from real people
 
 ## Setup
 
@@ -52,7 +53,32 @@ uv run subtitle-gen extract-ol                  # parse + deduplicate
 uv run subtitle-gen build-slots                 # extract slot fillers
 uv run subtitle-gen download-popularity         # SPL, Goodreads, Ottawa, etc.
 uv run subtitle-gen populate-popularity         # compute composite scores
+uv run subtitle-gen validate-pipeline           # read-only readiness checks
 ```
+
+### Pipeline contracts and validation
+
+The pipeline has explicit contract modules for the cross-stage state that feeds generation and serving:
+
+| Stage | Inputs | Outputs / contracts |
+|---|---|---|
+| Source ingestion | LOC MARC files and Open Library dumps | `subtitles` rows with ISBN/source metadata |
+| Slot extraction | Subtitle patterns plus spaCy validation | `pattern_matches` and strict `slot_fillers` candidates |
+| Popularity scoring | SPL, Open Library, Goodreads, NYT, Ottawa/library, and corpus frequency signals | `popularity_data.composite_score`, filler `popularity_score`, and calibrated threshold config values |
+| Remix precompute | Strict of-object fillers, spaCy vectors, article statistics | remix classifications, vector/scalar columns, embedding config keys |
+| Tuning | Generated samples, human ratings, LLM ratings, and strict proposal schemas | accepted config changes, rollback-capable proposal records, and rating snapshots |
+| Runtime/serving | Validated SQLite state and request parameters | `GeneratedSubtitle`, `subtitle_to_dict()`, CLI output, local HTTP, and Azure Functions payloads |
+
+Use `uv run subtitle-gen validate-pipeline` before tuning, serving, or exporting. It is read-only and fails non-zero when required tables/columns, config values, remix precompute state, popularity coverage, model IDs, or serving handlers are not ready.
+
+Model and weight state is grouped by purpose rather than treated as one loose dictionary:
+
+| Family | Examples |
+|---|---|
+| LLM models | rating model `github_copilot/gpt-5.4-mini`, proposal model `github_copilot/gpt-5.4`, jacket model `gpt-5.4-mini`, responses-only model family |
+| Sampling and tone | weighted sample spread, bias floor, tone targets, tier centers, accessibility thresholds |
+| Popularity | source weights for SPL/Open Library/Goodreads/NYT/library/frequency, exponent, blend defaults, slot multipliers |
+| Article and remix | article frequency thresholds, remix heuristic threshold, double-`of` rejection toggle, calibrated remix probability and similarity thresholds |
 
 ## Usage
 
@@ -140,7 +166,7 @@ Run `subtitle-gen calibrate-remix --help` to auto-tune remix parameters with LLM
 
 ### Tuning
 
-The system includes an autoresearch-inspired tuning loop that uses LLM evaluation to optimize 20 tunable parameters (tone targets, sampling spread, article thresholds, etc.):
+The system includes an autoresearch-inspired tuning loop that uses LLM evaluation to optimize tunable parameters (tone targets, sampling spread, popularity weights, article thresholds, etc.):
 
 ```bash
 uv run subtitle-gen tune                        # full pipeline (remix + tone)
@@ -182,6 +208,7 @@ Tuning goals and parameter bounds are documented in `tuning_goals.md`.
 | `slots` | Show available slot fillers |
 | `download-popularity` | Download all popularity data sources (SPL, Goodreads, Ottawa, NYT) |
 | `populate-popularity` | Build ISBN mappings + compute composite popularity scores |
+| `validate-pipeline` | Run read-only pipeline readiness checks |
 
 ## Architecture
 
@@ -197,6 +224,11 @@ src/subtitle_generator/
   feedback.py          # human feedback collection + summarization for tuning
   serve.py             # local HTTP server (stdlib)
   export_db.py         # mini DB export for deployment
+  parameter_state.py   # typed views over model IDs and tunable parameter families
+  pipeline_validation.py # read-only pipeline readiness checks
+  remix_state.py       # remix precompute contracts and runtime context
+  schema_contracts.py  # stage-aware SQLite schema contracts
+  tuning_state.py      # tuning proposal, decision, and rollback state records
   cli.py               # Click CLI entry point
 api/
   function_app.py      # Azure Functions v2 (same Python modules)

--- a/api/function_app.py
+++ b/api/function_app.py
@@ -1,7 +1,8 @@
 """Azure Functions v2 (Python) app wrapping subtitle-generator."""
 
+# ruff: noqa: E402
+
 import json
-import os
 import sys
 from pathlib import Path
 

--- a/data/populate_popularity.py
+++ b/data/populate_popularity.py
@@ -12,6 +12,8 @@ import sqlite3
 import sys
 import time
 from collections import defaultdict
+from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 
 DB_PATH = Path("data/db/subtitles.db")
@@ -25,6 +27,89 @@ NYT_PATH = Path("data/nyt_bestseller_lookup.json")
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from subtitle_generator.config import load_tuning_config, ALL_TUNABLE_PARAMS
+from subtitle_generator.parameter_state import PopularityParameters
+
+
+@dataclass
+class WorkLevelData:
+    work_spl: dict[str, dict]
+    work_ol: dict[str, int]
+    work_gr: dict[str, dict]
+    work_ottawa: dict[str, dict]
+    work_nyt: dict[str, dict]
+    all_works: set[str]
+
+
+@dataclass(frozen=True)
+class WorkPopularityRow:
+    work_key: str
+    spl_checkouts: int
+    spl_years: int
+    spl_earliest_pub_year: str
+    ol_edition_count: int
+    checkouts_per_year: float
+    editions_per_decade: float
+    gr_ratings_count: int
+    gr_average_rating: float
+    nyt_weeks_on_list: int
+    nyt_peak_rank: int | None
+    library_appearances: int
+    composite_score: float
+
+    def as_db_tuple(self) -> tuple:
+        return (
+            self.work_key,
+            self.spl_checkouts,
+            self.spl_years,
+            self.spl_earliest_pub_year,
+            self.ol_edition_count,
+            self.checkouts_per_year,
+            self.editions_per_decade,
+            self.gr_ratings_count,
+            self.gr_average_rating,
+            self.nyt_weeks_on_list,
+            self.nyt_peak_rank,
+            self.library_appearances,
+            self.composite_score,
+        )
+
+
+@dataclass(frozen=True)
+class PercentileModels:
+    spl: Callable[[float], float]
+    goodreads: Callable[[float], float]
+    open_library: Callable[[float], float]
+    library: Callable[[float], float]
+
+
+@dataclass(frozen=True)
+class ThresholdCalibration:
+    pop_threshold: float
+    mainstream_threshold: float
+    pop_center: float
+    mainstream_center: float
+    niche_center: float
+    pop_count: int
+    mainstream_count: int
+    niche_count: int
+
+    def as_config_values(self) -> dict[str, float]:
+        return {
+            "accessibility_threshold_pop": round(self.pop_threshold, 4),
+            "accessibility_threshold_mainstream": round(self.mainstream_threshold, 4),
+            "tier_center_pop": round(self.pop_center, 4),
+            "tier_center_mainstream": round(self.mainstream_center, 4),
+            "tier_center_niche": round(self.niche_center, 4),
+            "tone_target_pop_list_item": round(self.pop_center, 4),
+            "tone_target_pop_action_noun": round(self.pop_center, 4),
+            "tone_target_pop_of_object": round(self.pop_center, 4),
+            "tone_target_mainstream_list_item": round(self.mainstream_center, 4),
+            "tone_target_mainstream_action_noun": round(self.mainstream_center, 4),
+            "tone_target_mainstream_of_object": round(self.mainstream_center, 4),
+            "tone_target_niche_list_item": round(self.niche_center, 4),
+            "tone_target_niche_action_noun": round(self.niche_center, 4),
+            "tone_target_niche_of_object": round(self.niche_center, 4),
+        }
 
 
 def create_tables(conn: sqlite3.Connection):
@@ -145,6 +230,265 @@ def load_nyt(conn: sqlite3.Connection, nyt: dict) -> dict[str, dict]:
     return work_nyt
 
 
+def make_percentile_fn(values: list[float]) -> Callable[[float], float]:
+    """Build a fast percentile lookup from sorted values."""
+
+    import bisect
+
+    sorted_vals = sorted(values)
+    n = len(sorted_vals)
+    if n == 0:
+        return lambda x: 0.0
+
+    def pctile(x: float) -> float:
+        idx = bisect.bisect_left(sorted_vals, x)
+        return idx / n
+
+    return pctile
+
+
+def build_work_level_data(
+    conn: sqlite3.Connection,
+    spl: dict,
+    ol: dict,
+    gr: dict | None = None,
+    ottawa_isbn: dict | None = None,
+    nyt: dict | None = None,
+) -> WorkLevelData:
+    """Map third-party source dictionaries into work-keyed intermediate data."""
+
+    work_spl: dict[str, dict] = defaultdict(lambda: {"checkouts": 0, "years": set(), "pub_year": ""})
+    work_ol: dict[str, int] = {}
+
+    rows = conn.execute(
+        "SELECT isbn, work_key FROM isbn_aliases WHERE work_key IS NOT NULL"
+    ).fetchall()
+    isbn_to_work = {r[0]: r[1] for r in rows}
+    print(f"  ISBN->work mappings: {len(isbn_to_work):,}")
+
+    spl_matched = 0
+    for isbn, data in spl.items():
+        work = isbn_to_work.get(isbn)
+        if work:
+            w = work_spl[work]
+            w["checkouts"] += data["total_checkouts"]
+            w["years"] = max(len(w["years"]) if isinstance(w["years"], set) else w["years"], data["years_active"])
+            if data.get("pub_year") and (not w["pub_year"] or data["pub_year"] < w["pub_year"]):
+                w["pub_year"] = data["pub_year"]
+            spl_matched += 1
+
+    print(f"  SPL ISBNs matched to works: {spl_matched:,}")
+    print(f"  Unique works with SPL data: {len(work_spl):,}")
+
+    for _, data in ol.items():
+        work = data["work_key"]
+        ec = data["edition_count"]
+        work_ol[work] = max(work_ol.get(work, 0), ec)
+
+    print(f"  Unique works with OL data: {len(work_ol):,}")
+
+    if gr:
+        work_gr = load_goodreads(conn, gr)
+    else:
+        work_gr = {}
+        print("  Goodreads: skipped (no data)")
+
+    if ottawa_isbn:
+        work_ottawa = load_ottawa(conn, ottawa_isbn)
+    else:
+        work_ottawa = {}
+        print("  Ottawa library: skipped (no data)")
+
+    if nyt:
+        work_nyt = load_nyt(conn, nyt)
+    else:
+        work_nyt = {}
+        print("  NYT bestsellers: skipped (no data)")
+
+    all_works = (
+        set(work_spl.keys())
+        | set(work_ol.keys())
+        | set(work_gr.keys())
+        | set(work_ottawa.keys())
+        | set(work_nyt.keys())
+    )
+    return WorkLevelData(
+        work_spl=dict(work_spl),
+        work_ol=work_ol,
+        work_gr=work_gr,
+        work_ottawa=work_ottawa,
+        work_nyt=work_nyt,
+        all_works=all_works,
+    )
+
+
+def get_or_build_work_level_data(
+    conn: sqlite3.Connection,
+    spl: dict,
+    ol: dict,
+    gr: dict | None,
+    ottawa_isbn: dict | None,
+    nyt: dict | None,
+    work_data_cache: dict | None,
+) -> WorkLevelData:
+    """Reuse cached work-level data or populate the cache on first use."""
+
+    if work_data_cache is not None and "work_spl" in work_data_cache:
+        data = WorkLevelData(
+            work_spl=work_data_cache["work_spl"],
+            work_ol=work_data_cache["work_ol"],
+            work_gr=work_data_cache["work_gr"],
+            work_ottawa=work_data_cache["work_ottawa"],
+            work_nyt=work_data_cache["work_nyt"],
+            all_works=work_data_cache["all_works"],
+        )
+        print(f"  Using cached work-level data ({len(data.all_works):,} works)")
+        return data
+
+    data = build_work_level_data(conn, spl, ol, gr, ottawa_isbn, nyt)
+    if work_data_cache is not None:
+        work_data_cache["work_spl"] = data.work_spl
+        work_data_cache["work_ol"] = data.work_ol
+        work_data_cache["work_gr"] = data.work_gr
+        work_data_cache["work_ottawa"] = data.work_ottawa
+        work_data_cache["work_nyt"] = data.work_nyt
+        work_data_cache["all_works"] = data.all_works
+        print("  Cached work-level data for reuse")
+    return data
+
+
+def build_percentile_models(data: WorkLevelData) -> PercentileModels:
+    """Build per-source percentile models from work-level source data."""
+
+    spl_log_vals = [
+        math.log10(1 + d["checkouts"] / max(len(d["years"]) if isinstance(d["years"], set) else d["years"], 1))
+        for d in data.work_spl.values()
+        if d["checkouts"] > 0
+    ]
+    print(f"  SPL percentile base: {len(spl_log_vals):,} values")
+
+    gr_log_vals = [math.log10(1 + d["ratings_count"]) for d in data.work_gr.values()]
+    print(f"  GR percentile base: {len(gr_log_vals):,} values")
+
+    ol_log_vals = [math.log10(1 + ec) for ec in data.work_ol.values()]
+    print(f"  OL percentile base: {len(ol_log_vals):,} values")
+
+    lib_log_vals = [math.log10(1 + d["holds_count"]) for d in data.work_ottawa.values()]
+    print(f"  Ottawa percentile base: {len(lib_log_vals):,} values")
+
+    return PercentileModels(
+        spl=make_percentile_fn(spl_log_vals),
+        goodreads=make_percentile_fn(gr_log_vals),
+        open_library=make_percentile_fn(ol_log_vals),
+        library=make_percentile_fn(lib_log_vals),
+    )
+
+
+def score_work_popularity(
+    work: str,
+    data: WorkLevelData,
+    percentiles: PercentileModels,
+    params: PopularityParameters,
+) -> WorkPopularityRow:
+    """Compute a popularity_data row without writing to the database."""
+
+    spl_data = data.work_spl.get(work)
+    ol_ec = data.work_ol.get(work, 1)
+
+    spl_co = spl_data["checkouts"] if spl_data else 0
+    spl_yrs = spl_data["years"] if spl_data else 0
+    if isinstance(spl_yrs, set):
+        spl_yrs = len(spl_yrs)
+    pub_year = spl_data["pub_year"] if spl_data else ""
+
+    co_per_year = spl_co / max(spl_yrs, 1) if spl_co > 0 else 0.0
+    ed_per_decade = float(ol_ec)
+
+    signals = []
+    total_weight = 0.0
+
+    if spl_co > 0:
+        spl_norm = percentiles.spl(math.log10(1 + co_per_year))
+        signals.append((params.weight_spl, spl_norm))
+        total_weight += params.weight_spl
+
+    gr_data = data.work_gr.get(work)
+    if gr_data:
+        gr_norm = percentiles.goodreads(math.log10(1 + gr_data["ratings_count"]))
+        gr_ratings = gr_data["ratings_count"]
+        gr_avg = gr_data.get("average_rating", 0.0)
+        signals.append((params.weight_goodreads, gr_norm))
+        total_weight += params.weight_goodreads
+    else:
+        gr_ratings = 0
+        gr_avg = 0.0
+
+    can_data = data.work_ottawa.get(work)
+    if can_data:
+        lib_norm = percentiles.library(math.log10(1 + can_data["holds_count"]))
+        library_appearances = can_data["holds_count"]
+        signals.append((params.weight_library, lib_norm))
+        total_weight += params.weight_library
+    else:
+        library_appearances = 0
+
+    nyt_data = data.work_nyt.get(work)
+    if nyt_data:
+        nyt_weeks = nyt_data["weeks_on_list"]
+        nyt_rank = nyt_data["peak_rank"]
+        nyt_norm = min(1.0, 0.8 + 0.2 * math.log10(1 + nyt_weeks) / 2.0)
+        signals.append((params.weight_nyt, nyt_norm))
+        total_weight += params.weight_nyt
+    else:
+        nyt_weeks = 0
+        nyt_rank = None
+
+    if total_weight > 0:
+        demand_score = sum(w * s for w, s in signals) / total_weight
+    else:
+        demand_score = 0.0
+
+    ol_norm = percentiles.open_library(math.log10(1 + ol_ec))
+    confidence = min(
+        total_weight / (
+            params.weight_spl
+            + params.weight_goodreads
+            + params.weight_library
+            + params.weight_nyt
+        ),
+        1.0,
+    )
+    composite = confidence * demand_score + (1 - confidence) * ol_norm
+    if confidence == 0:
+        composite = min(composite, 0.5)
+
+    return WorkPopularityRow(
+        work_key=work,
+        spl_checkouts=spl_co,
+        spl_years=spl_yrs,
+        spl_earliest_pub_year=pub_year,
+        ol_edition_count=ol_ec,
+        checkouts_per_year=co_per_year,
+        editions_per_decade=ed_per_decade,
+        gr_ratings_count=gr_ratings,
+        gr_average_rating=gr_avg,
+        nyt_weeks_on_list=nyt_weeks,
+        nyt_peak_rank=nyt_rank,
+        library_appearances=library_appearances,
+        composite_score=composite,
+    )
+
+
+def persist_work_popularity_rows(
+    conn: sqlite3.Connection,
+    rows: list[WorkPopularityRow],
+) -> None:
+    conn.executemany(
+        "INSERT OR REPLACE INTO popularity_data VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [row.as_db_tuple() for row in rows],
+    )
+
+
 def populate_work_level(conn: sqlite3.Connection, spl: dict, ol: dict,
                        w_spl: float = 0.7, w_ol: float = 0.3, exponent: float = 1.0,
                        gr: dict | None = None, w_gr: float = 0.2,
@@ -160,211 +504,31 @@ def populate_work_level(conn: sqlite3.Connection, spl: dict, ol: dict,
     print(f"\nPopulating work-level popularity_data "
           f"(w_spl={w_spl}, w_ol={w_ol}, w_gr={w_gr}, w_lib={w_library}, w_nyt={w_nyt}, exp={exponent})...")
 
-    # Check if we can use cached work-level data
-    if work_data_cache is not None and "work_spl" in work_data_cache:
-        work_spl = work_data_cache["work_spl"]
-        work_ol = work_data_cache["work_ol"]
-        work_gr = work_data_cache["work_gr"]
-        work_ottawa = work_data_cache["work_ottawa"]
-        work_nyt = work_data_cache["work_nyt"]
-        all_works = work_data_cache["all_works"]
-        print(f"  Using cached work-level data ({len(all_works):,} works)")
-    else:
-        # Build work_key → aggregated signals
-        work_spl: dict[str, dict] = defaultdict(lambda: {"checkouts": 0, "years": set(), "pub_year": ""})
-        work_ol: dict[str, int] = {}
+    data = get_or_build_work_level_data(
+        conn, spl, ol, gr, ottawa_isbn, nyt, work_data_cache,
+    )
+    print(f"  Total unique works: {len(data.all_works):,}")
 
-        # Get isbn → work_key mapping
-        rows = conn.execute(
-            "SELECT isbn, work_key FROM isbn_aliases WHERE work_key IS NOT NULL"
-        ).fetchall()
-        isbn_to_work = {r[0]: r[1] for r in rows}
-        print(f"  ISBN->work mappings: {len(isbn_to_work):,}")
+    params = PopularityParameters(
+        weight_spl=w_spl,
+        weight_ol=w_ol,
+        weight_goodreads=w_gr,
+        weight_nyt=w_nyt,
+        weight_library=w_library,
+        weight_frequency=0.0,
+        exponent=exponent,
+    )
+    percentiles = build_percentile_models(data)
 
-        # Aggregate SPL by work_key (dedup across editions)
-        spl_matched = 0
-        for isbn, data in spl.items():
-            work = isbn_to_work.get(isbn)
-            if work:
-                w = work_spl[work]
-                w["checkouts"] += data["total_checkouts"]
-                w["years"] = max(len(w["years"]) if isinstance(w["years"], set) else w["years"], data["years_active"])
-                if data.get("pub_year") and (not w["pub_year"] or data["pub_year"] < w["pub_year"]):
-                    w["pub_year"] = data["pub_year"]
-                spl_matched += 1
-
-        print(f"  SPL ISBNs matched to works: {spl_matched:,}")
-        print(f"  Unique works with SPL data: {len(work_spl):,}")
-
-        # OL edition counts are already per-work in the lookup
-        for isbn, data in ol.items():
-            work = data["work_key"]
-            ec = data["edition_count"]
-            work_ol[work] = max(work_ol.get(work, 0), ec)
-
-        print(f"  Unique works with OL data: {len(work_ol):,}")
-
-        # Goodreads: map to work_keys
-        if gr:
-            work_gr = load_goodreads(conn, gr)
-        else:
-            work_gr = {}
-            print("  Goodreads: skipped (no data)")
-
-        # Ottawa library: map ISBN-keyed data to work_keys
-        if ottawa_isbn:
-            work_ottawa = load_ottawa(conn, ottawa_isbn)
-        else:
-            work_ottawa = {}
-            print("  Ottawa library: skipped (no data)")
-
-        # NYT bestsellers: map ISBN-keyed data to work_keys
-        if nyt:
-            work_nyt = load_nyt(conn, nyt)
-        else:
-            work_nyt = {}
-            print("  NYT bestsellers: skipped (no data)")
-
-        all_works = set(work_spl.keys()) | set(work_ol.keys()) | set(work_gr.keys()) | set(work_ottawa.keys()) | set(work_nyt.keys())
-
-        # Cache for reuse
-        if work_data_cache is not None:
-            work_data_cache["work_spl"] = dict(work_spl)
-            work_data_cache["work_ol"] = work_ol
-            work_data_cache["work_gr"] = work_gr
-            work_data_cache["work_ottawa"] = work_ottawa
-            work_data_cache["work_nyt"] = work_nyt
-            work_data_cache["all_works"] = all_works
-            print(f"  Cached work-level data for reuse")
-
-    # Merge into popularity_data
-    print(f"  Total unique works: {len(all_works):,}")
-
-    # Precompute percentile lookup functions for each source.
-    # Each converts a log1p(raw_value) to a [0, 1] percentile rank.
-    import bisect
-
-    def make_pctile_fn(values: list[float]):
-        """Build a fast percentile lookup from sorted values."""
-        sorted_vals = sorted(values)
-        n = len(sorted_vals)
-        if n == 0:
-            return lambda x: 0.0
-        def pctile(x):
-            idx = bisect.bisect_left(sorted_vals, x)
-            return idx / n
-        return pctile
-
-    spl_log_vals = [math.log10(1 + d["checkouts"] / max(len(d["years"]) if isinstance(d["years"], set) else d["years"], 1))
-                    for d in work_spl.values() if d["checkouts"] > 0]
-    spl_pctile = make_pctile_fn(spl_log_vals)
-    print(f"  SPL percentile base: {len(spl_log_vals):,} values")
-
-    gr_log_vals = [math.log10(1 + d["ratings_count"]) for d in work_gr.values()]
-    gr_pctile = make_pctile_fn(gr_log_vals)
-    print(f"  GR percentile base: {len(gr_log_vals):,} values")
-
-    ol_log_vals = [math.log10(1 + ec) for ec in work_ol.values()]
-    ol_pctile = make_pctile_fn(ol_log_vals)
-    print(f"  OL percentile base: {len(ol_log_vals):,} values")
-
-    lib_log_vals = [math.log10(1 + d["holds_count"]) for d in work_ottawa.values()]
-    lib_pctile = make_pctile_fn(lib_log_vals)
-    print(f"  Ottawa percentile base: {len(lib_log_vals):,} values")
-
-    batch = []
-    for work in all_works:
-        spl_data = work_spl.get(work)
-        ol_ec = work_ol.get(work, 1)
-
-        spl_co = spl_data["checkouts"] if spl_data else 0
-        spl_yrs = spl_data["years"] if spl_data else 0
-        if isinstance(spl_yrs, set):
-            spl_yrs = len(spl_yrs)
-        pub_year = spl_data["pub_year"] if spl_data else ""
-
-        # Temporal normalization
-        co_per_year = spl_co / max(spl_yrs, 1) if spl_co > 0 else 0.0
-        # For editions: normalize by decades since first edition (approximate)
-        ed_per_decade = float(ol_ec)  # we don't have pub year for OL, use raw for now
-
-        # Compute per-source normalized signals (percentile of log1p within each source)
-        # and build weighted average over AVAILABLE sources only.
-        # OL is always available as a fallback/prior, not a peer demand signal.
-
-        signals = []  # list of (weight, normalized_value) for observed demand sources
-        total_weight = 0.0
-
-        if spl_co > 0:
-            spl_norm = spl_pctile(math.log10(1 + co_per_year))
-            signals.append((w_spl, spl_norm))
-            total_weight += w_spl
-
-        gr_data = work_gr.get(work)
-        if gr_data:
-            gr_norm = gr_pctile(math.log10(1 + gr_data["ratings_count"]))
-            gr_ratings = gr_data["ratings_count"]
-            gr_avg = gr_data.get("average_rating", 0.0)
-            signals.append((w_gr, gr_norm))
-            total_weight += w_gr
-        else:
-            gr_ratings = 0
-            gr_avg = 0.0
-
-        # Ottawa library signal
-        can_data = work_ottawa.get(work)
-        if can_data:
-            lib_norm = lib_pctile(math.log10(1 + can_data["holds_count"]))
-            library_appearances = can_data["holds_count"]
-            signals.append((w_library, lib_norm))
-            total_weight += w_library
-        else:
-            library_appearances = 0
-
-        # NYT bestseller signal — binary boost: any appearance floors at 0.8
-        nyt_data = work_nyt.get(work)
-        if nyt_data:
-            nyt_weeks = nyt_data["weeks_on_list"]
-            nyt_rank = nyt_data["peak_rank"]
-            # Binary: on-list = 0.8 base + modest weeks increment (capped at 1.0)
-            nyt_norm = min(1.0, 0.8 + 0.2 * math.log10(1 + nyt_weeks) / 2.0)
-            signals.append((w_nyt, nyt_norm))
-            total_weight += w_nyt
-        else:
-            nyt_weeks = 0
-            nyt_rank = None
-
-        # Composite: weighted average over observed demand sources
-        if total_weight > 0:
-            demand_score = sum(w * s for w, s in signals) / total_weight
-        else:
-            demand_score = 0.0
-
-        # OL as prior/fallback: blend with demand score based on confidence
-        ol_norm = ol_pctile(math.log10(1 + ol_ec))
-        confidence = min(total_weight / (w_spl + w_gr + w_library + w_nyt), 1.0)
-        composite = confidence * demand_score + (1 - confidence) * ol_norm
-
-        # Cap OL-only works (no demand evidence) below pop threshold.
-        # Edition count is a supply metric, not demand — shouldn't make something pop.
-        if confidence == 0:
-            composite = min(composite, 0.5)  # firmly below mainstream center
-
-        batch.append((work, spl_co, spl_yrs, pub_year, ol_ec, co_per_year, ed_per_decade,
-                       gr_ratings, gr_avg, nyt_weeks, nyt_rank, library_appearances, composite))
-
+    batch: list[WorkPopularityRow] = []
+    for work in data.all_works:
+        batch.append(score_work_popularity(work, data, percentiles, params))
         if len(batch) >= 50000:
-            conn.executemany(
-                "INSERT OR REPLACE INTO popularity_data VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                batch,
-            )
+            persist_work_popularity_rows(conn, batch)
             batch.clear()
 
     if batch:
-        conn.executemany(
-            "INSERT OR REPLACE INTO popularity_data VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            batch,
-        )
+        persist_work_popularity_rows(conn, batch)
     conn.commit()
 
     total = conn.execute("SELECT COUNT(*) FROM popularity_data").fetchone()[0]
@@ -383,19 +547,13 @@ def populate_work_level(conn: sqlite3.Connection, spl: dict, ol: dict,
     n = len(vals)
     print(f"  Composite score distribution:")
     print(f"    min={vals[0]:.3f}, median={vals[n//2]:.3f}, mean={sum(vals)/n:.3f}, "
-          f"p90={vals[int(n*0.9)]:.3f}, max={vals[-1]:.3f}")
+           f"p90={vals[int(n*0.9)]:.3f}, max={vals[-1]:.3f}")
 
 
-def score_fillers_level1(conn: sqlite3.Connection):
-    """Compute Level 1 popularity scores for fillers with ISBN sources."""
-    print("\nScoring fillers (Level 1: ISBN-direct)...")
+def update_level1_filler_scores(conn: sqlite3.Connection) -> int:
+    """Write direct ISBN/work-level filler scores using top-3 source mean."""
 
-    # For each filler, aggregate popularity across all source works.
-    # Strategy: top-3 mean of composite scores (not MAX).
-    # MAX inflates common words that appear in hundreds of niche books
-    # plus one popular book (e.g. "Future": avg=0.19, MAX=2.52 across 440 works).
-    # Top-3 mean is robust: requires multiple popular source works.
-    updated = conn.execute("""
+    return conn.execute("""
         UPDATE slot_fillers SET
             popularity_score = (
                 SELECT AVG(top_score) FROM (
@@ -417,14 +575,12 @@ def score_fillers_level1(conn: sqlite3.Connection):
             JOIN subtitles s ON sfs.subtitle_id = s.id
             JOIN isbn_aliases ia ON ia.isbn = s.isbn
             JOIN popularity_data pd ON pd.work_key = ia.work_key
-            WHERE sfs.slot_filler_id = slot_fillers.id
-        )
+             WHERE sfs.slot_filler_id = slot_fillers.id
+         )
     """).rowcount
-    conn.commit()
 
-    print(f"  Updated {updated:,} fillers with Level 1 scores (top-3 mean)")
 
-    # Stats
+def print_level1_filler_stats(conn: sqlite3.Connection) -> None:
     for stype in ["list_item", "action_noun", "of_object"]:
         row = conn.execute("""
             SELECT COUNT(*), AVG(popularity_score), MAX(popularity_score)
@@ -439,11 +595,26 @@ def score_fillers_level1(conn: sqlite3.Connection):
                   f"avg={row[1]:.3f} max={row[2]:.3f}")
 
 
-def score_fillers_fallback(conn: sqlite3.Connection):
-    """Set fallback scores for fillers without Level 1 data."""
-    print("\nSetting fallback scores (Level 0: freq-based)...")
+def score_fillers_level1(conn: sqlite3.Connection):
+    """Compute Level 1 popularity scores for fillers with ISBN sources."""
+    print("\nScoring fillers (Level 1: ISBN-direct)...")
 
-    updated = conn.execute("""
+    # For each filler, aggregate popularity across all source works.
+    # Strategy: top-3 mean of composite scores (not MAX).
+    # MAX inflates common words that appear in hundreds of niche books
+    # plus one popular book (e.g. "Future": avg=0.19, MAX=2.52 across 440 works).
+    # Top-3 mean is robust: requires multiple popular source works.
+    updated = update_level1_filler_scores(conn)
+    conn.commit()
+
+    print(f"  Updated {updated:,} fillers with Level 1 scores (top-3 mean)")
+    print_level1_filler_stats(conn)
+
+
+def update_fallback_filler_scores(conn: sqlite3.Connection) -> int:
+    """Write log-frequency fallback scores for fillers without Level 1 data."""
+
+    return conn.execute("""
         UPDATE slot_fillers SET
             popularity_score = CASE
                 WHEN freq > 0 THEN log(1 + freq) / log(10)
@@ -453,6 +624,13 @@ def score_fillers_fallback(conn: sqlite3.Connection):
             popularity_confidence = 0.0
         WHERE popularity_level IS NULL AND mode = 'strict'
     """).rowcount
+
+
+def score_fillers_fallback(conn: sqlite3.Connection):
+    """Set fallback scores for fillers without Level 1 data."""
+    print("\nSetting fallback scores (Level 0: freq-based)...")
+
+    updated = update_fallback_filler_scores(conn)
     conn.commit()
 
     print(f"  Set fallback for {updated:,} fillers")
@@ -490,6 +668,68 @@ def report(conn: sqlite3.Connection):
         print(f"  {stype}: {filler} | pop={score:.3f} freq_score={freq_score:.3f} (freq={freq})")
 
 
+def compute_classification_scores(
+    rows: list[tuple[int, float | None]],
+    blend: float,
+    pop_default: float,
+) -> list[float]:
+    """Blend frequency and popularity scores for threshold classification."""
+
+    scores = []
+    for freq, pop_score in rows:
+        score_freq = math.log10(1 + freq)
+        ps = pop_score if pop_score is not None else pop_default
+        scores.append((1 - blend) * score_freq + blend * ps)
+    return sorted(scores)
+
+
+def calibrate_threshold_values(scores: list[float]) -> ThresholdCalibration:
+    """Compute p92/p64 thresholds and tier centers from sorted scores."""
+
+    if not scores:
+        raise ValueError("Cannot calibrate thresholds without filler scores")
+
+    n = len(scores)
+
+    def pctile(p: int) -> float:
+        idx = int(n * p / 100)
+        return scores[min(idx, n - 1)]
+
+    pop_thresh = pctile(92)
+    main_thresh = pctile(64)
+
+    pop_scores = [s for s in scores if s >= pop_thresh]
+    main_scores = [s for s in scores if main_thresh <= s < pop_thresh]
+    niche_scores = [s for s in scores if s < main_thresh]
+
+    pop_center = pop_scores[len(pop_scores) // 2] if pop_scores else pop_thresh
+    main_center = main_scores[len(main_scores) // 2] if main_scores else (pop_thresh + main_thresh) / 2
+    niche_center = niche_scores[len(niche_scores) // 2] if niche_scores else main_thresh / 2
+
+    return ThresholdCalibration(
+        pop_threshold=pop_thresh,
+        mainstream_threshold=main_thresh,
+        pop_center=pop_center,
+        mainstream_center=main_center,
+        niche_center=niche_center,
+        pop_count=len(pop_scores),
+        mainstream_count=len(main_scores),
+        niche_count=len(niche_scores),
+    )
+
+
+def write_threshold_config(conn: sqlite3.Connection, params: dict[str, float]) -> None:
+    """Persist calibrated threshold/tone target values to config."""
+
+    conn.execute("CREATE TABLE IF NOT EXISTS config (key TEXT PRIMARY KEY, value TEXT)")
+    for key, value in params.items():
+        conn.execute(
+            "INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)",
+            (key, str(value)),
+        )
+    conn.commit()
+
+
 def calibrate_thresholds(conn: sqlite3.Connection):
     """Compute data-driven thresholds from popularity_score distribution.
 
@@ -504,89 +744,41 @@ def calibrate_thresholds(conn: sqlite3.Connection):
     blend = cfg.get("pop_classification_blend", 0.9)
     pop_default = cfg.get("pop_missing_default", 0.1)
 
-    # Compute blended classification scores for all strict fillers
     rows = conn.execute(
         "SELECT freq, popularity_score FROM slot_fillers WHERE mode = 'strict'"
     ).fetchall()
 
-    scores = []
-    for freq, pop_score in rows:
-        score_freq = math.log10(1 + freq)
-        ps = pop_score if pop_score is not None else pop_default
-        blended = (1 - blend) * score_freq + blend * ps
-        scores.append(blended)
-
-    scores.sort()
+    scores = compute_classification_scores(rows, blend, pop_default)
     n = len(scores)
-
-    def pctile(p):
-        idx = int(n * p / 100)
-        return scores[min(idx, n - 1)]
-
-    # Pop threshold: p92 (top ~8%)
-    pop_thresh = pctile(92)
-    # Mainstream threshold: p64 (top ~36%)
-    main_thresh = pctile(64)
-
-    # Tier centers: median of each tier's scores
-    pop_scores = [s for s in scores if s >= pop_thresh]
-    main_scores = [s for s in scores if main_thresh <= s < pop_thresh]
-    niche_scores = [s for s in scores if s < main_thresh]
-
-    pop_center = pop_scores[len(pop_scores) // 2] if pop_scores else pop_thresh
-    main_center = main_scores[len(main_scores) // 2] if main_scores else (pop_thresh + main_thresh) / 2
-    niche_center = niche_scores[len(niche_scores) // 2] if niche_scores else main_thresh / 2
+    calibration = calibrate_threshold_values(scores)
 
     print(f"\n=== Threshold Calibration (blend={blend}) ===")
-    print(f"  Distribution: n={n}, min={scores[0]:.3f}, median={pctile(50):.3f}, max={scores[-1]:.3f}")
+    print(f"  Distribution: n={n}, min={scores[0]:.3f}, median={scores[min(int(n * 50 / 100), n - 1)]:.3f}, max={scores[-1]:.3f}")
     print(f"\n  Recommended thresholds:")
-    print(f"    accessibility_threshold_pop:         {pop_thresh:.3f}  (p92, {len(pop_scores)} fillers)")
-    print(f"    accessibility_threshold_mainstream:   {main_thresh:.3f}  (p64, {len(main_scores)} fillers)")
-    print(f"    niche: {len(niche_scores)} fillers")
+    print(f"    accessibility_threshold_pop:         {calibration.pop_threshold:.3f}  (p92, {calibration.pop_count} fillers)")
+    print(f"    accessibility_threshold_mainstream:   {calibration.mainstream_threshold:.3f}  (p64, {calibration.mainstream_count} fillers)")
+    print(f"    niche: {calibration.niche_count} fillers")
     print(f"\n  Recommended tier centers:")
-    print(f"    tier_center_pop:         {pop_center:.3f}")
-    print(f"    tier_center_mainstream:  {main_center:.3f}")
-    print(f"    tier_center_niche:       {niche_center:.3f}")
+    print(f"    tier_center_pop:         {calibration.pop_center:.3f}")
+    print(f"    tier_center_mainstream:  {calibration.mainstream_center:.3f}")
+    print(f"    tier_center_niche:       {calibration.niche_center:.3f}")
 
     # Show example fillers near boundaries
-    print(f"\n  Example fillers near pop threshold ({pop_thresh:.3f}):")
+    print(f"\n  Example fillers near pop threshold ({calibration.pop_threshold:.3f}):")
     boundary_rows = conn.execute(
         "SELECT slot_type, filler, freq, popularity_score FROM slot_fillers "
         "WHERE mode = 'strict' AND slot_type IN ('list_item', 'action_noun', 'of_object') "
-        "ORDER BY ABS(popularity_score - ?) LIMIT 10", (pop_thresh,)
+        "ORDER BY ABS(popularity_score - ?) LIMIT 10", (calibration.pop_threshold,)
     ).fetchall()
     for stype, filler, freq, ps in boundary_rows:
         score_freq = math.log10(1 + freq)
         ps_val = ps if ps is not None else pop_default
         blended = (1 - blend) * score_freq + blend * ps_val
-        tier = "POP" if blended >= pop_thresh else ("MAIN" if blended >= main_thresh else "NICHE")
+        tier = "POP" if blended >= calibration.pop_threshold else ("MAIN" if blended >= calibration.mainstream_threshold else "NICHE")
         print(f"    {tier:5s} {blended:.3f}  {stype:15s}  {filler}")
 
-    # Write to config table
-    params = {
-        "accessibility_threshold_pop": round(pop_thresh, 4),
-        "accessibility_threshold_mainstream": round(main_thresh, 4),
-        "tier_center_pop": round(pop_center, 4),
-        "tier_center_mainstream": round(main_center, 4),
-        "tier_center_niche": round(niche_center, 4),
-        "tone_target_pop_list_item": round(pop_center, 4),
-        "tone_target_pop_action_noun": round(pop_center, 4),
-        "tone_target_pop_of_object": round(pop_center, 4),
-        "tone_target_mainstream_list_item": round(main_center, 4),
-        "tone_target_mainstream_action_noun": round(main_center, 4),
-        "tone_target_mainstream_of_object": round(main_center, 4),
-        "tone_target_niche_list_item": round(niche_center, 4),
-        "tone_target_niche_action_noun": round(niche_center, 4),
-        "tone_target_niche_of_object": round(niche_center, 4),
-    }
-
-    conn.execute("CREATE TABLE IF NOT EXISTS config (key TEXT PRIMARY KEY, value TEXT)")
-    for key, value in params.items():
-        conn.execute(
-            "INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)",
-            (key, str(value))
-        )
-    conn.commit()
+    params = calibration.as_config_values()
+    write_threshold_config(conn, params)
 
     print(f"\n  Written {len(params)} config values to DB.")
 

--- a/docs/pipeline-end-to-end.md
+++ b/docs/pipeline-end-to-end.md
@@ -1,0 +1,759 @@
+# End-to-end pipeline and tuning guide
+
+This document explains how subtitle-generator works from raw third-party data
+through population, tuning, and serving. It is the readable companion to the
+contract modules and `subtitle-gen validate-pipeline`, not a replacement for
+those checks.
+
+## TL;DR
+
+subtitle-generator mines real catalog subtitles, extracts pieces that fit the
+pattern `X, Y, and the Z of W`, assigns each piece frequency/popularity/tone
+state, optionally precomputes remix vectors, and serves a generator that draws
+weighted slot fillers from SQLite.
+
+The important rule is: **population creates the raw and derived universe,
+serving reads that universe to assemble subtitles and jackets, and tuning only
+changes the numeric state that influences scoring and generation.**
+
+Tuning does not train a model. It changes numeric config rows in SQLite,
+generates samples, asks an LLM to rate quality, measures tone separation, keeps
+or reverts the proposed config change, and records the result.
+
+## Architecture at a glance
+
+There are three main concerns:
+
+1. **Population** builds and enriches SQLite state from external data.
+2. **Serving** reads validated SQLite state to generate subtitles, jackets, and
+   API responses.
+3. **Tuning** evaluates output quality and feeds accepted numeric changes back
+   into `config` and derived scoring state.
+
+```mermaid
+flowchart LR
+    sources[Third-party data sources] --> population[Population]
+    population --> db[(SQLite pipeline state)]
+    db --> serving[Serving]
+    serving --> outputs[CLI, local web, Azure API, jackets]
+    outputs --> feedback[Human and LLM feedback]
+    feedback --> tuning[Tuning]
+    tuning --> config[(config rows and derived scores)]
+    config --> db
+```
+
+The highest-level data handoff is:
+
+```text
+raw records -> subtitles -> slot fillers -> scored fillers -> generated output
+```
+
+The most important join/key transition is:
+
+```text
+ISBN -> Open Library work_key -> source work popularity -> slot filler score
+```
+
+Runtime generation is filler-centric. Popularity scoring is work-centric.
+Source extraction is ISBN/title/subtitle-centric.
+
+## Population: build-time data and derived state
+
+Population is everything that creates or enriches the SQLite database before
+normal runtime generation. It owns raw ingestion, slot extraction, popularity
+scoring, threshold calibration, and remix precompute.
+
+```mermaid
+flowchart TD
+    loc[LOC MARC files] --> extract[extract]
+    ol[Open Library edition dump] --> extractOl[extract-ol]
+    extract --> subtitles[(subtitles)]
+    extractOl --> subtitles
+    extractOl --> aliases[(isbn_aliases / work_key)]
+
+    subtitles --> slots[build-slots]
+    slots --> matches[(pattern_matches)]
+    slots --> fillers[(slot_fillers)]
+    slots --> sources[(slot_filler_sources)]
+
+    spl[SPL checkouts] --> pop[populate-popularity]
+    gr[Goodreads ratings] --> pop
+    ottawa[Ottawa/library holds] --> pop
+    nyt[NYT bestsellers] --> pop
+    aliases --> pop
+    pop --> popularity[(popularity_data)]
+    pop --> fillers
+    pop --> config[(config thresholds and tone centers)]
+
+    fillers --> remix[precompute-vectors]
+    remix --> fillers
+    remix --> config
+
+    config --> validate[validate-pipeline]
+    fillers --> validate
+    popularity --> validate
+    subtitles --> validate
+```
+
+Normal build order:
+
+```bash
+uv run subtitle-gen download --parts all
+uv run subtitle-gen extract
+uv run subtitle-gen download-ol
+uv run subtitle-gen extract-ol
+uv run subtitle-gen build-slots
+uv run subtitle-gen download-popularity
+uv run subtitle-gen populate-popularity
+uv run subtitle-gen precompute-vectors
+uv run subtitle-gen validate-pipeline
+```
+
+`validate-pipeline` checks full serving readiness, including the remix
+precompute contract. If you stop before `precompute-vectors`, non-remix
+experiments may still work locally, but validation will report that the DB is
+not ready for the full runtime path.
+
+### Population inputs
+
+The generator is grounded in real book/catalog data:
+
+| Source | Used for | Shape in the pipeline |
+|---|---|---|
+| Library of Congress MARC bulk files | Primary raw subtitle corpus | Downloaded, parsed, and inserted into `subtitles`. |
+| Open Library edition dump | Additional subtitles and ISBN/work identity | Extracted into `subtitles`; provides `work_key` and edition-count prior. |
+| Seattle Public Library checkout data | Demand signal | ISBN-keyed checkouts mapped to Open Library works. |
+| Goodreads/UCSD Book Graph | Demand/engagement signal | ISBN-keyed ratings counts mapped to works. |
+| Ottawa/Canadian library data | Library holds/appearances signal | ISBN-keyed library demand mapped to works. |
+| NYT bestseller data | Bestseller signal | ISBN-keyed bestseller appearances mapped to works. |
+
+Human ratings are not population inputs. They are feedback used by tuning and
+analysis.
+
+### Subtitle extraction
+
+Extraction turns LOC/Open Library records into normalized `subtitles` rows.
+
+Important fields include:
+
+- `title`
+- `subtitle`
+- `lang`
+- source metadata such as `lccn`, `source_file`, and `isbn`
+
+This stage does not decide whether a subtitle is usable for generation. It
+preserves source material so downstream stages can match, filter, and attribute
+results.
+
+### Pattern matching and slot extraction
+
+`build-slots` looks for subtitles matching:
+
+```text
+X, Y, and [the/a/an] Z of [the/a/an] W
+```
+
+The regex match is only the first gate. `slots.py` then uses spaCy and
+orthographic filters to reject catalog noise, weak/jargon fillers, truncation,
+encoding artifacts, all-caps MARC leakage, implausible action nouns, and bad
+of-objects.
+
+Outputs:
+
+| Table | Meaning |
+|---|---|
+| `pattern_matches` | Source subtitle decomposed into list items, action noun, of-object, and observed articles. |
+| `slot_fillers` | Deduplicated filler inventory by slot type with frequency and later scoring/precompute columns. |
+| `slot_filler_sources` | Many-to-many link from filler to source subtitle; used for attribution and popularity scoring. |
+
+Slot types include:
+
+- `list_item`
+- `action_noun`
+- `of_object`
+- remix sub-parts: `of_modifier`, `of_head`, `of_topic`, `of_complement`
+
+The generator samples only `mode = 'strict'` fillers.
+
+### Popularity scoring
+
+Popularity scoring converts third-party demand/supply data into numeric work
+and filler scores.
+
+`data/populate_popularity.py` first maps source dictionaries into work-keyed
+intermediate structures:
+
+- `work_spl`
+- `work_ol`
+- `work_gr`
+- `work_ottawa`
+- `work_nyt`
+- `all_works`
+
+Each source is normalized onto a percentile scale using `log10(1 + raw_value)`.
+Demand sources are combined as a weighted average over the signals present for
+a work:
+
+$$
+\text{demand\_score} =
+\frac{\sum(\text{source\_weight} \cdot \text{source\_percentile})}
+     {\sum(\text{source\_weight})}
+$$
+
+Open Library edition count is treated as a prior/confidence signal rather than
+as a peer demand source. The final work composite is:
+
+$$
+\text{composite} =
+\text{confidence} \cdot \text{demand\_score}
++ (1 - \text{confidence}) \cdot \text{open\_library\_percentile}
+$$
+
+where confidence is based on the amount of demand-source weight actually
+observed. Works with no demand sources are capped so Open Library alone cannot
+make them look like high-demand pop titles. NYT appearances get a high floor
+because even partial bestseller-list presence is meaningful.
+
+The persisted result is one row per work in `popularity_data`.
+
+Runtime generation samples fillers, not works, so work scores are pushed down
+to `slot_fillers`. For fillers with source works, the Level 1 score is the mean
+of the top three source-work composite scores. This avoids overvaluing a filler
+because it appeared once in a very popular book. Fillers without work-level
+backing use a frequency fallback:
+
+$$
+\text{fallback\_score} = \log_{10}(1 + \text{freq})
+$$
+
+The resulting filler columns are:
+
+- `popularity_score`
+- `popularity_level`
+- `popularity_confidence`
+
+### Calibration: the population-to-serving handoff
+
+After popularity changes, calibration derives the numeric bands that serving
+uses for tone targeting and jacket tone selection:
+
+- `accessibility_threshold_pop`
+- `accessibility_threshold_mainstream`
+- `tier_center_pop`
+- `tier_center_mainstream`
+- `tier_center_niche`
+- `tone_target_{tier}_{slot}`
+
+These values are written to `config`. They are the handoff between build-time
+scoring and runtime concepts such as "pop", "mainstream", and "niche".
+
+#### Popularity thresholds and Gaussian bias
+
+The threshold cutoffs are not Gaussian. Calibration sorts strict fillers by a
+classification score:
+
+$$
+\begin{aligned}
+\text{classification\_score} &=
+(1 - \text{pop\_classification\_blend}) \cdot \log_{10}(1 + \text{freq}) \\
+&\quad + \text{pop\_classification\_blend} \cdot \text{popularity\_score}
+\end{aligned}
+$$
+
+It then chooses percentile cutoffs from that observed distribution:
+
+| Config key | Source |
+|---|---|
+| `accessibility_threshold_pop` | 92nd percentile: top roughly 8% of strict fillers. |
+| `accessibility_threshold_mainstream` | 64th percentile: next roughly 28% are mainstream; below that is niche. |
+| `tier_center_pop` | Median score within the pop band. |
+| `tier_center_mainstream` | Median score within the mainstream band. |
+| `tier_center_niche` | Median score within the niche band. |
+
+The Gaussian part happens after those cutoffs exist. Serving uses the tier
+centers as soft targets, not hard buckets, so nearby fillers get boosted and
+distant fillers get suppressed:
+
+$$
+\begin{aligned}
+\text{bias} &=
+\exp\left(-\left(\frac{\text{filler\_score} - \text{tone\_target}}
+{\text{weighted\_sample\_spread}}\right)^2\right) \\
+\text{weight} &=
+\text{base\_weight} \cdot
+\left(\text{weighted\_sample\_bias\_floor}
++ (1 - \text{weighted\_sample\_bias\_floor}) \cdot \text{bias}\right)
+\end{aligned}
+$$
+
+Jacket tone selection uses the same idea: a subtitle's accessibility score is
+compared with the pop/mainstream/niche centers, and `sample_tone_spread`
+controls how sharply probability falls off with distance. So the percentile
+cutoffs define the bands; the Gaussian makes runtime selection gradual instead
+of cliff-like.
+
+### Remix precompute
+
+Remixing can create a new of-object from source-derived sub-parts.
+
+| Type | Original shape | Remixed shape |
+|---|---|---|
+| Type 1 | compound noun phrase | `modifier + head` |
+| Type 2 | prepositional noun phrase | `topic + prep + complement` |
+
+`precompute_remix_data()` classifies strict `of_object` fillers and stores:
+
+- `remix_type`
+- `remix_prep`
+- `remix_word_count`
+- `vector_sum`
+- `token_count`
+- `centroid_dot`
+- `norm_sq`
+
+It also stores config constants:
+
+- `embedding_version`
+- `centroid_norm`
+- `avg_cross_sim_t1`
+- `avg_cross_sim_t2`
+- `embedding_centroid` for the development fallback path
+
+#### Remix coherence: centroids and cross terms
+
+The centroid fields are the remix coherence shortcut. During precompute, the
+pipeline embeds every strict source-derived `of_object` and averages those
+embeddings into a centroid: the semantic center of real source phrases. A
+candidate remix is considered more plausible when its combined embedding points
+in roughly the same direction as that centroid.
+
+The runtime path does not store or load full vectors for every request. Instead,
+it stores enough scalar data to approximate cosine similarity:
+
+$$
+\text{similarity} \approx
+\frac{\text{dot}(\text{remix\_parts}, \text{centroid})}
+     {\text{norm}(\text{remix\_parts}) \cdot \text{norm}(\text{centroid})}
+$$
+
+The pieces map as follows:
+
+| Field | What it means |
+|---|---|
+| `vector_sum` | Sum of token embeddings for one filler or remix sub-part. |
+| `token_count` | Number of embedded tokens used to build `vector_sum`. |
+| `centroid_dot` | Dot product between that filler's `vector_sum` and the source-phrase centroid. |
+| `norm_sq` | Squared length of that filler's `vector_sum`. |
+| `centroid_norm` | Length of the source-phrase centroid. |
+| `avg_cross_sim_t1` | Average modifier/head similarity, used for Type 1 remixes. |
+| `avg_cross_sim_t2` | Average topic/complement similarity, used for Type 2 remixes. |
+
+The "cross" values are cross-term corrections, not diagram crossings. When two
+parts are combined, the length of the combined vector depends on each part's
+own length plus how much the parts point in similar directions. The runtime
+approximates that combined length as:
+
+$$
+\sum_i \text{norm\_sq}_i
++ \sum_{i<j}
+  2 \cdot \sqrt{\text{norm\_sq}_i}
+    \cdot \sqrt{\text{norm\_sq}_j}
+    \cdot \text{avg\_cross\_sim}
+$$
+
+That is enough for `_approx_cosine_sim()` to reject low-coherence remixes
+without loading spaCy, NumPy, or full embedding vectors during serving.
+
+At runtime, the preferred path uses this scalar decomposition. That lets the
+web app and deployed handler evaluate remix coherence without doing large NLP
+or vector work inside the request path.
+
+## Serving: runtime generation, jackets, and APIs
+
+Serving reads populated SQLite state. It should not parse third-party source
+files, recalculate popularity from raw sources, or run tuning decisions.
+
+```mermaid
+flowchart LR
+    cli[CLI commands] --> core[core Python modules]
+    local[Local web server serve.py] --> handlers[handlers.py]
+    azure[Azure Functions function_app.py] --> handlers
+    web[Alpine web UI] --> local
+    handlers --> core
+    core --> db[(SQLite)]
+```
+
+`handlers.py` is the transport-neutral API boundary. It owns request parsing
+and response shapes for:
+
+- `handle_generate`
+- `handle_jacket`
+- `handle_rate`
+- `handle_health`
+
+Local serving (`serve.py`) wraps those handlers with stdlib HTTP and adds local
+SSE streaming for full jacket generation. Azure Functions wrap the same shared
+handler semantics. The deployed jacket path is prompt-only because the hosted
+mini database/runtime does not carry the full local generation environment.
+
+The web UI is intentionally thin. It calls the API, renders color-coded slots,
+streams jacket progress, and stores feedback through `/api/rate`; generation
+decisions remain server-side.
+
+### Subtitle generation
+
+```mermaid
+flowchart TD
+    request[CLI or API request] --> parse[parse tone, locks, remix params]
+    parse --> db[(SQLite)]
+    db --> candidates[load strict slot candidates]
+    db --> cfg[load config params]
+    cfg --> tone[resolve tone targets]
+    tone --> adjust[apply slot multipliers]
+    candidates --> sample[weighted sampling]
+    adjust --> sample
+    sample --> remixDecision{remix?}
+    remixDecision -->|no| articles[restore articles]
+    remixDecision -->|yes| remix[compose remix parts and check similarity]
+    remix --> articles
+    articles --> assemble[assemble GeneratedSubtitle]
+    assemble --> sources[lookup source attribution]
+    sources --> response[CLI text or API payload]
+```
+
+`generate_subtitle()` is the stable runtime facade. Internally it:
+
+1. Creates a seeded RNG when a seed is supplied.
+2. Validates lock combinations.
+3. Loads strict candidates for list items, action nouns, and of-objects.
+4. Adjusts requested tone targets with per-slot multipliers.
+5. Samples two list items, one action noun, and one of-object.
+6. Optionally attempts of-object remixing.
+7. Restores action/of-object articles from corpus statistics and heuristics.
+8. Title-cases and returns a `GeneratedSubtitle`.
+
+### Sampling weights
+
+Base sampling weight blends frequency and popularity:
+
+$$
+\begin{aligned}
+\text{base\_weight} &=
+(1 - \text{pop\_base\_weight\_blend}) \cdot \sqrt{\text{freq}} \\
+&\quad + \text{pop\_base\_weight\_blend} \cdot \sqrt{\text{popularity\_score}}
+\end{aligned}
+$$
+
+When a tone target is present, the base weight is multiplied by a Gaussian-like
+bias around the target:
+
+$$
+\begin{aligned}
+\text{filler\_score} &=
+(1 - \text{pop\_classification\_blend}) \cdot \log_{10}(1 + \text{freq}) \\
+&\quad + \text{pop\_classification\_blend} \cdot \text{popularity\_score} \\
+\text{bias} &=
+\exp\left(-\left(\frac{\text{filler\_score} - \text{tone\_target}}
+{\text{weighted\_sample\_spread}}\right)^2\right) \\
+\text{weight} &\leftarrow
+\text{weight} \cdot
+\left(\text{weighted\_sample\_bias\_floor}
++ (1 - \text{weighted\_sample\_bias\_floor}) \cdot \text{bias}\right)
+\end{aligned}
+$$
+
+"Pop" and "niche" do not select from separate hard-coded lists. They use the
+same candidate pools with different numeric targets.
+
+### Locks and runtime API surface
+
+Locks are a testing/UI affordance. Supported keys are:
+
+- `item1`
+- `item2`
+- `action_noun`
+- `of_object`
+- `of_modifier`
+- `of_head`
+- `of_topic`
+- `of_complement`
+
+The code rejects invalid mixes, such as combining an `of_object` lock with remix
+sub-part locks, or mixing Type 1 and Type 2 remix locks.
+
+### Jacket generation
+
+Jacket generation is downstream of subtitle generation. It does not change the
+subtitle pipeline state.
+
+```mermaid
+sequenceDiagram
+    participant UI as CLI/Web UI
+    participant API as handler/server
+    participant DB as SQLite
+    participant SDK as Copilot SDK
+
+    UI->>API: subtitle + model
+    API->>DB: compute accessibility and tone tier
+    API->>API: build system/user prompt once
+    API-->>UI: stream progress events
+    API->>SDK: send prompt to selected model
+    SDK-->>API: markdown jacket
+    API->>API: validate required sections and retry if needed
+    API-->>UI: terminal result or error event
+```
+
+The prompt tone is chosen from the subtitle's accessibility score unless the
+caller supplies an override. The generated jacket is expected to contain:
+
+- `## Title`
+- `## Subtitle`
+- `## Internal Concept`
+- `## Back Cover`
+- `## Review 1`
+- `## Review 2`
+
+Public output strips `## Internal Concept` by default. For the local web server,
+`serve.py` precomputes the DB-backed prompt and passes that exact prompt to
+generation, so the prompt shown in the UI matches the generated jacket. The
+frontend treats SSE `result` and `error` events as terminal so the UI does not
+wait for EOF after completion.
+
+## Tuning: feedback-driven config changes
+
+Tuning is an autoresearch-style hill-climbing loop: it makes one bounded config
+change, measures whether output improved, then keeps or reverts that change.
+
+It manipulates:
+
+- numeric config rows in `config`
+- derived popularity scores in `slot_fillers` when population-related params
+  change
+- derived thresholds/tone targets when classification-related params change
+- result logs and best-state snapshots
+
+It does not manipulate:
+
+- source records in `subtitles`
+- extracted pattern matches
+- the generation algorithm itself
+- any trained model weights
+
+### Tuning loop
+
+```mermaid
+flowchart TD
+    goals[tuning_goals.md] --> propose[LLM proposes one ParamProposal]
+    history[results.tsv + best snapshot] --> propose
+    bounds[parsed parameter bounds] --> propose
+
+    propose --> clamp[clamp to allowed bounds]
+    clamp --> snapshot[record old config value]
+    snapshot --> apply[apply config change]
+
+    apply --> affected{parameter kind}
+    affected -->|source weights / exponent| repop[repopulate popularity]
+    affected -->|classification blend / missing default| calibrate[recalibrate thresholds]
+    affected -->|runtime-only| eval[generate samples]
+    repop --> calibrate
+    calibrate --> eval
+
+    eval --> rate[LLM rates quality]
+    eval --> sep[measure pop/niche separation]
+    rate --> score[composite score]
+    sep --> score
+
+    score --> keep{better than before?}
+    keep -->|yes| persist[keep config and record decision]
+    keep -->|no| revert[rollback config and record decision]
+    persist --> log[append results.tsv]
+    revert --> log
+```
+
+Calibration always follows repopulation because changing source weights or
+exponents changes the score distribution used to derive tier thresholds and
+tone centers.
+
+### Proposal inputs
+
+The proposer sees:
+
+- `tuning_goals.md`
+- parameter bounds parsed from the goals table
+- recent experiment history
+- regime-change markers when the available parameter set changes
+- current parameter values
+
+The proposal schema is strict:
+
+```text
+ParamProposal:
+  param: str
+  new_value: float
+  reasoning: str
+```
+
+Only one parameter is changed at a time. Bounds are enforced before evaluation.
+
+### Evaluation metrics
+
+The evaluation harness uses two primary scores.
+
+Quality:
+
+1. Generate a sample set.
+2. Ask the rating model to score each subtitle for coherence, evocativeness,
+   and surprise on a 1-10 scale.
+3. Normalize the result to 0-1.
+
+Tone separation:
+
+1. Generate pop-targeted and niche-targeted sample sets with fixed seeds.
+2. Convert each filler to its blended classification score.
+3. Build histograms over the observed score range.
+4. Return `1 - histogram_overlap`.
+
+Composite:
+
+$$
+\text{composite} =
+\text{quality\_weight} \cdot \text{quality}
++ (1 - \text{quality\_weight}) \cdot \text{separation}
+$$
+
+### Keep/revert semantics
+
+The tuning code represents a proposed mutation as a `ConfigChange`:
+
+```text
+param
+old_value
+new_value
+```
+
+If the new composite score wins, the config row stays. If it loses, the change
+is reverted through the same config-writing path and the config cache is
+invalidated. `ProposalDecision` records before/after quality, separation, and
+composite scores.
+
+This is why `config` is the tuning boundary: a proposal can be applied, measured,
+kept, or rolled back without rewriting source data.
+
+### Human feedback paths
+
+```mermaid
+flowchart TD
+    web["Web UI: How'd it land?"] --> rate["/api/rate"]
+    cli["CLI review prompt"] --> store["store_rating"]
+    spot["Spot Check page / CLI spot-check"] --> store
+    rate --> store
+    store --> ratings[(human_ratings)]
+
+    ratings --> review["review-ratings"]
+    review --> goals["tuning_goals.md proposed diff"]
+    goals --> tune["tune loop context"]
+```
+
+Human feedback is stored as durable data, not immediately applied as a config
+change. It can include:
+
+- thumbs up/down
+- system tone
+- human tone override
+- tags such as `interesting`, `realistic`, `funny`, `boring`, `broken`, and
+  `nonsense`
+- free text
+- config snapshot
+- source (`web_user`, `spot_check`, etc.)
+
+`review-ratings` summarizes mismatch patterns and asks the proposer model for
+targeted edits to `tuning_goals.md`. Those edits are displayed for human review;
+they are not applied silently.
+
+### Parameter dependency map
+
+| Parameter family | Affects | Needs repopulate? | Needs recalibration? |
+|---|---|---:|---:|
+| `pop_weight_spl`, `pop_weight_ol`, `pop_weight_gr`, `pop_weight_nyt`, `pop_weight_library` | Work-level `composite_score` and filler `popularity_score` | Yes | Yes |
+| `pop_exponent` | Source score contrast before work-level scoring | Yes | Yes |
+| `pop_classification_blend` | Tier classification and tone-bias alignment | No | Yes |
+| `pop_missing_default` | Missing-popularity filler classification | No | Yes |
+| `pop_base_weight_blend` | Runtime base sampling weights | No | No |
+| `weighted_sample_spread`, `weighted_sample_bias_floor` | Runtime tone-bias strength | No | No |
+| `pop_slot_mult_*` | Per-slot runtime tone targets | No | No |
+| `article_*` | Runtime article restoration | No | No |
+| `remix_reject_double_of` | Runtime remix filtering | No | No |
+
+This distinction matters because source-weight changes are expensive and rewrite
+derived data, while runtime-only changes can be evaluated by generating new
+samples from the existing database.
+
+## Validation and readiness
+
+`subtitle-gen validate-pipeline` is read-only. It checks that the database and
+Python contracts are ready for generation/tuning/serving.
+
+Validation includes:
+
+- required tables and columns by stage
+- numeric config values for known tunable params
+- known model IDs
+- remix precompute config and columns
+- strict filler popularity coverage
+- runtime candidate availability
+- shared handler functions
+
+Use it before tuning, serving, exporting, or investigating strange runtime
+behavior.
+
+## Debugging mental model
+
+When behavior looks wrong, identify which concern owns the symptom:
+
+| Symptom | First layer to inspect |
+|---|---|
+| Bad source/citation or missing attribution | `slot_filler_sources`, `find_source`, mini DB export. |
+| Weird catalog/jargon filler | `slots.py` validation filters and `slot_fillers.mode`. |
+| Pop mode feels too obscure | popularity scores, thresholds, `pop_classification_blend`, tone targets. |
+| Pop and niche feel similar | `measure_tone_separation`, tone targets, sampling spread/bias floor. |
+| Tuning keeps rejecting good-looking changes | metric scale, threshold calibration, results history/regime markers. |
+| Remix output is ungrammatical | remix classification, article stats, similarity threshold, double-of rejection. |
+| Web and CLI generate different shapes | `handlers.py` response contract vs CLI formatting. |
+| Jacket prompt does not match output | `build_jacket_prompt`, `generate_jacket_from_prompt`, SSE result payload. |
+
+## Reference: main artifacts
+
+| Artifact | Role |
+|---|---|
+| `data\db\subtitles.db` | Full local SQLite database built from source data. |
+| `subtitles` | Extracted source subtitle records plus title/source metadata. |
+| `pattern_matches` | Raw matched subtitles decomposed into list/action/of-object fields. |
+| `slot_fillers` | Canonical runtime filler inventory, including frequency, popularity, remix, vector, and scalar state. |
+| `slot_filler_sources` | Links fillers back to source subtitles/books for attribution and popularity scoring. |
+| `popularity_data` | Work-level demand/supply signals and `composite_score`. |
+| `config` | Tuned numeric parameters and precompute constants. Defaults live in `config.py`. |
+| `human_ratings` | Human feedback, tone overrides, tags, and config snapshots. |
+| `schema_contracts.py` | Required table/column contracts by pipeline stage. |
+| `parameter_state.py` | Typed views over model IDs and parameter families. |
+| `remix_state.py` | Remix precompute readiness and runtime context contracts. |
+| `pipeline_validation.py` | Read-only readiness checks composed into `subtitle-gen validate-pipeline`. |
+
+## Reference: parameter and model state
+
+The project has several different kinds of "model" and "weight" state. They
+should not be conflated.
+
+| Family | Stored in | Used by |
+|---|---|---|
+| LLM model IDs | Python constants in `parameter_state.py` | rating, proposal, jacket generation |
+| Tunable numeric params | Defaults in `config.py`, DB overrides in `config` | scoring, generation, tuning |
+| Popularity source weights | `pop_weight_*` config params | `populate-popularity` and repopulate during tuning |
+| Popularity blending params | `pop_base_weight_blend`, `pop_tone_blend`, `pop_classification_blend`, `pop_missing_default` | sampling, tone bias, tier classification |
+| Tone thresholds and targets | auto-calibrated `config` rows | generation and jacket tone selection |
+| Article params | `article_*` config rows and article stats blobs | article restoration |
+| Remix params/constants | `remix_*`, `embedding_version`, centroid/cross-sim config rows | remix composition and validation |
+
+`parameter_state.py` exposes typed views so each stage can ask for only the
+state it needs: sampling params, popularity params, blend params, article params,
+remix params, tier thresholds, tone targets, runtime generation params, and the
+model registry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "subtitle-generator"
-version = "0.2.0"
+version = "0.3.0"
 description = "Generate bizarre book subtitles by mixing real parts from Library of Congress MARC records"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,20 @@ packages = ["src/subtitle_generator"]
 [tool.uv.sources]
 en-core-web-sm = { url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl" }
 en-core-web-md = { url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.8.0/en_core_web_md-3.8.0-py3-none-any.whl" }
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+    "ruff>=0.15.12",
+    "ty>=0.0.32",
+]
+
+[tool.ty.src]
+include = [
+    "src/subtitle_generator/parameter_state.py",
+    "src/subtitle_generator/pipeline_validation.py",
+    "src/subtitle_generator/remix_state.py",
+    "src/subtitle_generator/schema_contracts.py",
+    "src/subtitle_generator/tuning_state.py",
+    "tests/test_pipeline_characterization.py",
+]

--- a/src/subtitle_generator/analyze.py
+++ b/src/subtitle_generator/analyze.py
@@ -2,13 +2,10 @@
 
 import json
 import sqlite3
-from collections import Counter
-from pathlib import Path
 
 import click
 import spacy
 
-from subtitle_generator.extract import DB_PATH
 
 # Function words to keep literal in templates (lowercased)
 LITERAL_TOKENS = {

--- a/src/subtitle_generator/calibrate.py
+++ b/src/subtitle_generator/calibrate.py
@@ -19,7 +19,7 @@ from subtitle_generator.eval_harness import (
     DEFAULT_RATER_MODEL,
     rate_batch_raw,
 )
-from subtitle_generator.generate import generate_subtitle, _load_remix_context
+from subtitle_generator.generate import generate_subtitle
 
 
 def _compute_subtitle_centroid(conn: sqlite3.Connection, nlp) -> np.ndarray | None:
@@ -102,7 +102,7 @@ def run_calibration(
     click.echo(f"  Baseline similarity to real subtitles: "
                f"mean={baseline['mean']:.3f}, std={baseline['std']:.3f}, "
                f"p10={baseline['p10']:.3f}")
-    click.echo(f"  (Remixed subtitles will be somewhat lower — that's expected)\n")
+    click.echo("  (Remixed subtitles will be somewhat lower — that's expected)\n")
 
     # --- Phase 1: Sweep min_sim at remix_prob=1.0 ---
     click.echo("Phase 1: Finding optimal embedding threshold (min_sim)")
@@ -204,8 +204,8 @@ def run_calibration(
     )
     conn.commit()
 
-    click.echo(f"\n=== Calibration Complete ===")
+    click.echo("\n=== Calibration Complete ===")
     click.echo(f"  Optimal min_sim:    {best_min_sim:.2f}")
     click.echo(f"  Optimal remix_prob: {best_remix_prob:.1f}")
     click.echo(f"  Baseline sim:       {baseline['mean']:.3f} (±{baseline['std']:.3f})")
-    click.echo(f"\nThese values are now the defaults for 'generate --remix'.")
+    click.echo("\nThese values are now the defaults for 'generate --remix'.")

--- a/src/subtitle_generator/cli.py
+++ b/src/subtitle_generator/cli.py
@@ -1,5 +1,6 @@
 """CLI entry point for subtitle-generator."""
 
+import sqlite3
 import sys
 from pathlib import Path
 
@@ -17,8 +18,9 @@ from subtitle_generator.export_db import build_mini_db, export_data, export_mini
 from subtitle_generator.generate import TONE_TARGETS, format_sources, generate_subtitle, precompute_remix_data, slot_stats
 from subtitle_generator.jacket import (
     TONE_HIGH, TONE_LOW, TONE_MEDIUM,
-    compute_accessibility, generate_jacket, sample_tone,
+    compute_accessibility, generate_jacket,
 )
+from subtitle_generator.pipeline_validation import format_validation_report, validate_pipeline
 from subtitle_generator.slots import build_slots, ensure_slot_tables
 
 
@@ -1090,6 +1092,24 @@ def populate_popularity(w_spl, w_ol, w_gr, w_library, w_nyt, exponent, skip_cali
     subprocess.run(args, check=True)
 
     click.echo("\nDone! Popularity scores updated.")
+
+
+@cli.command("validate-pipeline")
+@click.option("--db", "db_path", type=click.Path(path_type=Path), default=DB_PATH, help="SQLite database to validate.")
+@click.option("--embedding-version", default="2", show_default=True, help="Expected remix embedding version.")
+def validate_pipeline_cmd(db_path: Path, embedding_version: str):
+    """Run read-only pipeline readiness checks."""
+    try:
+        conn = sqlite3.connect(f"{db_path.resolve().as_uri()}?mode=ro", uri=True)
+    except sqlite3.OperationalError as exc:
+        raise click.ClickException(f"Unable to open database read-only: {db_path}") from exc
+    try:
+        report = validate_pipeline(conn, expected_embedding_version=embedding_version)
+    finally:
+        conn.close()
+    click.echo(format_validation_report(report))
+    if not report.ok:
+        raise click.exceptions.Exit(1)
 
 
 if __name__ == "__main__":

--- a/src/subtitle_generator/eval_harness.py
+++ b/src/subtitle_generator/eval_harness.py
@@ -11,24 +11,28 @@ import asyncio
 import json
 import math
 import sqlite3
+import warnings
 
 import click
 import litellm
 from pydantic import BaseModel
 
-# Suppress noisy litellm coroutine warnings
-import warnings
-warnings.filterwarnings("ignore", message="coroutine.*was never awaited")
-
 from subtitle_generator.config import get_tone_targets
 from subtitle_generator.generate import generate_subtitle
+from subtitle_generator.parameter_state import (
+    DEFAULT_PROPOSER_MODEL as DEFAULT_PROPOSER_MODEL,
+    DEFAULT_RATER_MODEL,
+    RESPONSES_ONLY_MODELS,
+)
+
+# Suppress noisy litellm coroutine warnings
+warnings.filterwarnings("ignore", message="coroutine.*was never awaited")
 
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
 
-DEFAULT_RATER_MODEL = "github_copilot/gpt-5.4-mini"
-DEFAULT_PROPOSER_MODEL = "github_copilot/gpt-5.4"
+_RESPONSES_ONLY_MODELS = RESPONSES_ONLY_MODELS
 
 # ---------------------------------------------------------------------------
 # Pydantic schemas
@@ -54,10 +58,6 @@ class ParamProposal(BaseModel):
 # ---------------------------------------------------------------------------
 # structured_completion — auto-dispatch structured output
 # ---------------------------------------------------------------------------
-
-# Models that require the /responses API (not /chat/completions)
-_RESPONSES_ONLY_MODELS = {"gpt-5.4-mini", "gpt-5.4", "gpt-5.4-nano"}
-
 
 def _needs_responses_api(model: str) -> bool:
     """Check if this model needs the /responses API."""

--- a/src/subtitle_generator/extract_openlibrary.py
+++ b/src/subtitle_generator/extract_openlibrary.py
@@ -9,7 +9,7 @@ from urllib.request import Request, urlopen
 
 import click
 
-from subtitle_generator.extract import DATA_DIR, _clean_subtitle
+from subtitle_generator.extract import DATA_DIR
 
 OL_DUMP_URL = "https://openlibrary.org/data/ol_dump_editions_latest.txt.gz"
 OL_DUMP_FILENAME = "ol_dump_editions_latest.txt.gz"

--- a/src/subtitle_generator/generate.py
+++ b/src/subtitle_generator/generate.py
@@ -3,7 +3,6 @@
 import json
 import math
 import random
-import re
 import sqlite3
 from dataclasses import dataclass, field
 
@@ -12,6 +11,10 @@ import inflect
 from titlecase import titlecase as _lib_titlecase
 
 from subtitle_generator.config import DEFAULT_TONE_TARGETS, load_tuning_config
+from subtitle_generator.remix_state import (
+    RemixRuntimeContext,
+    assert_remix_precompute_state,
+)
 
 _inflect_engine = inflect.engine()
 
@@ -42,6 +45,23 @@ class GeneratedSubtitle:
     remix_similarity: float | None = None
     of_article: str = ""
     action_article: str = "the"
+
+
+@dataclass(frozen=True)
+class GenerationCandidates:
+    list_rows: list[tuple]
+    action_rows: list[tuple]
+    obj_rows: list[tuple]
+
+
+@dataclass
+class SelectedSubtitleParts:
+    items: list[str]
+    action_noun: str
+    of_object: str
+    remixed: bool
+    remix_parts: dict
+    remix_similarity: float | None
 
 
 def _weighted_sample(
@@ -108,7 +128,7 @@ TONE_TARGETS = DEFAULT_TONE_TARGETS
 # --- Remix infrastructure ---
 
 # Module-level cache for remix context (lazy-loaded)
-_remix_ctx: dict | None = None
+_remix_ctx: RemixRuntimeContext | None = None
 
 # Sentinel for embedding precompute version checks
 _EMBEDDING_VERSION = "2"
@@ -291,7 +311,7 @@ def precompute_remix_data(conn: sqlite3.Connection) -> dict:
     return stats
 
 
-def _load_remix_context(conn: sqlite3.Connection) -> dict:
+def _load_remix_context(conn: sqlite3.Connection) -> RemixRuntimeContext:
     """Lazy-load remix context from pre-computed scalar decomposition in DB.
 
     Requires precompute_remix_data() to have been run first (version 2+).
@@ -304,6 +324,7 @@ def _load_remix_context(conn: sqlite3.Connection) -> dict:
     # Check for pre-computed embeddings
     row = conn.execute("SELECT value FROM config WHERE key = 'embedding_version'").fetchone()
     if row is not None and int(row[0]) >= 2:
+        assert_remix_precompute_state(conn, _EMBEDDING_VERSION)
         # Version 2+: scalar decomposition (no numpy needed)
         centroid_norm_row = conn.execute(
             "SELECT value FROM config WHERE key = 'centroid_norm'"
@@ -351,16 +372,16 @@ def _load_remix_context(conn: sqlite3.Connection) -> dict:
             elif key == "article_stats_action_noun":
                 article_stats_action = parsed
 
-        _remix_ctx = {
-            "centroid_norm": centroid_norm,
-            "avg_cross_sim_t1": avg_cross_sim_t1,
-            "avg_cross_sim_t2": avg_cross_sim_t2,
-            "filler_scalars": filler_scalars,
-            "config": config,
-            "precomputed": True,
-            "article_stats_of": article_stats_of,
-            "article_stats_action": article_stats_action,
-        }
+        _remix_ctx = RemixRuntimeContext(
+            precomputed=True,
+            centroid_norm=centroid_norm,
+            avg_cross_sim_t1=avg_cross_sim_t1,
+            avg_cross_sim_t2=avg_cross_sim_t2,
+            filler_scalars=filler_scalars,
+            config=config,
+            article_stats_of=article_stats_of,
+            article_stats_action=article_stats_action,
+        )
         return _remix_ctx
 
     if row is not None:
@@ -404,11 +425,14 @@ def _load_remix_context(conn: sqlite3.Connection) -> dict:
         elif key == "article_stats_action_noun":
             article_stats_action = parsed
 
-    _remix_ctx = {
-        "nlp": nlp, "centroid": centroid, "config": config, "precomputed": False,
-        "article_stats_of": article_stats_of,
-        "article_stats_action": article_stats_action,
-    }
+    _remix_ctx = RemixRuntimeContext(
+        precomputed=False,
+        nlp=nlp,
+        centroid=centroid,
+        config=config,
+        article_stats_of=article_stats_of,
+        article_stats_action=article_stats_action,
+    )
     return _remix_ctx
 
 
@@ -714,136 +738,187 @@ def _infer_of_article(
     return ""
 
 
-def generate_subtitle(
-    conn: sqlite3.Connection, seed: int | None = None,
-    tone_target: dict[str, float] | None = None,
-    remix_prob: float = 0.0, min_sim: float = 0.0,
-    locks: dict[str, str] | None = None,
-) -> GeneratedSubtitle:
-    """Generate one random subtitle in the 'X, Y, and the Z of W' pattern.
+def _make_rng(seed: int | None) -> random.Random | None:
+    return random.Random(seed) if seed is not None else None
 
-    tone_target maps slot_type → log10 target score for filler biasing.
-    remix_prob: probability of remixing a multi-word of-object (0.0 = never, 1.0 = always).
-    min_sim: minimum cosine similarity for embedding coherence filter.
-    locks: optional dict mapping slot keys to locked values.
-        Supported keys: item1, item2, action_noun, of_object,
-        of_modifier, of_head, of_topic, of_complement.
-    """
-    rng = None
-    if seed is not None:
-        rng = random.Random(seed)
 
-    # Validate lock combinations
-    if locks:
-        type1_keys = {"of_modifier", "of_head"}
-        type2_keys = {"of_topic", "of_complement"}
-        has_type1 = bool(type1_keys & locks.keys())
-        has_type2 = bool(type2_keys & locks.keys())
-        if has_type1 and has_type2:
-            raise ValueError("Cannot mix Type 1 (of_modifier/of_head) and Type 2 (of_topic/of_complement) locks")
-        sub_part_keys = type1_keys | type2_keys
-        if "of_object" in locks and (sub_part_keys & locks.keys()):
-            raise ValueError("Cannot combine of_object lock with sub-part locks")
+def _validate_generation_locks(locks: dict[str, str] | None) -> None:
+    if not locks:
+        return
+    type1_keys = {"of_modifier", "of_head"}
+    type2_keys = {"of_topic", "of_complement"}
+    has_type1 = bool(type1_keys & locks.keys())
+    has_type2 = bool(type2_keys & locks.keys())
+    if has_type1 and has_type2:
+        raise ValueError("Cannot mix Type 1 (of_modifier/of_head) and Type 2 (of_topic/of_complement) locks")
+    sub_part_keys = type1_keys | type2_keys
+    if "of_object" in locks and (sub_part_keys & locks.keys()):
+        raise ValueError("Cannot combine of_object lock with sub-part locks")
 
-    list_rows = conn.execute(
-        "SELECT filler, freq, popularity_score FROM slot_fillers WHERE slot_type = 'list_item' AND mode = 'strict'"
-    ).fetchall()
-    action_rows = conn.execute(
-        "SELECT filler, freq, popularity_score FROM slot_fillers WHERE slot_type = 'action_noun' AND mode = 'strict'"
-    ).fetchall()
-    obj_rows = conn.execute(
-        "SELECT filler, freq, popularity_score FROM slot_fillers WHERE slot_type = 'of_object' AND mode = 'strict'"
-    ).fetchall()
 
-    # Adjust required-row checks based on locks
+def _load_generation_candidates(conn: sqlite3.Connection) -> GenerationCandidates:
+    return GenerationCandidates(
+        list_rows=conn.execute(
+            "SELECT filler, freq, popularity_score FROM slot_fillers WHERE slot_type = 'list_item' AND mode = 'strict'"
+        ).fetchall(),
+        action_rows=conn.execute(
+            "SELECT filler, freq, popularity_score FROM slot_fillers WHERE slot_type = 'action_noun' AND mode = 'strict'"
+        ).fetchall(),
+        obj_rows=conn.execute(
+            "SELECT filler, freq, popularity_score FROM slot_fillers WHERE slot_type = 'of_object' AND mode = 'strict'"
+        ).fetchall(),
+    )
+
+
+def _has_enough_candidates(
+    candidates: GenerationCandidates,
+    locks: dict[str, str] | None,
+) -> bool:
     list_needed = 2 - sum(1 for k in ("item1", "item2") if locks and k in locks)
     action_needed = not (locks and "action_noun" in locks)
     obj_needed = not (locks and "of_object" in locks)
+    return (
+        len(candidates.list_rows) >= list_needed
+        and (not action_needed or bool(candidates.action_rows))
+        and (not obj_needed or bool(candidates.obj_rows))
+    )
 
-    if (len(list_rows) < list_needed) or \
-       (action_needed and not action_rows) or \
-       (obj_needed and not obj_rows):
-        return GeneratedSubtitle(
-            text="(not enough fillers — run 'build-slots' first)",
-            item1="", item2="", action_noun="", of_object="",
-        )
 
-    list_target = tone_target.get("list_item") if tone_target else None
-    action_target = tone_target.get("action_noun") if tone_target else None
-    obj_target = tone_target.get("of_object") if tone_target else None
+def _not_enough_fillers_subtitle() -> GeneratedSubtitle:
+    return GeneratedSubtitle(
+        text="(not enough fillers — run 'build-slots' first)",
+        item1="", item2="", action_noun="", of_object="",
+    )
 
-    # Apply per-slot popularity multipliers to tone targets
-    if tone_target is not None:
-        cfg = load_tuning_config(conn)
-        if list_target is not None:
-            list_target *= cfg.get("pop_slot_mult_list_item", 1.0)
-        if action_target is not None:
-            action_target *= cfg.get("pop_slot_mult_action_noun", 1.0)
-        if obj_target is not None:
-            obj_target *= cfg.get("pop_slot_mult_of_object", 1.0)
 
-    # Build adjusted tone_target dict with per-slot multipliers applied
-    # (used for remix path which receives the dict, not individual scalars)
-    adjusted_tone_target = None
-    if tone_target is not None:
-        adjusted_tone_target = {
-            "list_item": list_target,
-            "action_noun": action_target,
-            "of_object": obj_target,
-        }
+def _adjust_tone_targets(
+    conn: sqlite3.Connection,
+    tone_target: dict[str, float] | None,
+) -> dict[str, float] | None:
+    if tone_target is None:
+        return None
+    cfg = load_tuning_config(conn)
+    return {
+        "list_item": (
+            tone_target.get("list_item") * cfg.get("pop_slot_mult_list_item", 1.0)
+            if tone_target.get("list_item") is not None else None
+        ),
+        "action_noun": (
+            tone_target.get("action_noun") * cfg.get("pop_slot_mult_action_noun", 1.0)
+            if tone_target.get("action_noun") is not None else None
+        ),
+        "of_object": (
+            tone_target.get("of_object") * cfg.get("pop_slot_mult_of_object", 1.0)
+            if tone_target.get("of_object") is not None else None
+        ),
+    }
 
-    # Draw or lock list items (avoid duplicates with locked value)
+
+def _pick_list_items(
+    list_rows: list[tuple],
+    rng: random.Random | None,
+    list_target: float | None,
+    conn: sqlite3.Connection,
+    locks: dict[str, str] | None,
+) -> list[str]:
     if locks and "item1" in locks and "item2" in locks:
-        items = [locks["item1"], locks["item2"]]
-    elif locks and "item1" in locks:
+        return [locks["item1"], locks["item2"]]
+    if locks and "item1" in locks:
         pool = [(f, w) for f, w in list_rows if f != locks["item1"]]
         if not pool:
             pool = list_rows
-        items = [locks["item1"], _weighted_sample(pool, 1, rng, list_target, conn)[0]]
-    elif locks and "item2" in locks:
+        return [locks["item1"], _weighted_sample(pool, 1, rng, list_target, conn)[0]]
+    if locks and "item2" in locks:
         pool = [(f, w) for f, w in list_rows if f != locks["item2"]]
         if not pool:
             pool = list_rows
-        items = [_weighted_sample(pool, 1, rng, list_target, conn)[0], locks["item2"]]
-    else:
-        items = _weighted_sample(list_rows, 2, rng, list_target, conn)
+        return [_weighted_sample(pool, 1, rng, list_target, conn)[0], locks["item2"]]
+    return _weighted_sample(list_rows, 2, rng, list_target, conn)
 
-    # Draw or lock action noun
+
+def _pick_action_noun(
+    action_rows: list[tuple],
+    rng: random.Random | None,
+    action_target: float | None,
+    conn: sqlite3.Connection,
+    locks: dict[str, str] | None,
+) -> str:
     if locks and "action_noun" in locks:
-        action_noun = locks["action_noun"]
-    else:
-        action_noun = _weighted_sample(action_rows, 1, rng, action_target, conn)[0]
+        return locks["action_noun"]
+    return _weighted_sample(action_rows, 1, rng, action_target, conn)[0]
 
-    # Draw or lock of-object
+
+def _pick_of_object_and_remix(
+    conn: sqlite3.Connection,
+    obj_rows: list[tuple],
+    rng: random.Random | None,
+    adjusted_tone_target: dict[str, float] | None,
+    remix_prob: float,
+    min_sim: float,
+    locks: dict[str, str] | None,
+) -> tuple[str, bool, dict, float | None]:
+    obj_target = adjusted_tone_target.get("of_object") if adjusted_tone_target else None
     remix_similarity = None
     if locks and "of_object" in locks:
-        of_object = locks["of_object"]
-        remixed = False
-        remix_parts = {}
-    else:
-        of_object = _weighted_sample(obj_rows, 1, rng, obj_target, conn)[0]
-        remixed = False
-        remix_parts = {}
+        return locks["of_object"], False, {}, remix_similarity
 
-        # Check for sub-part locks that force remix
-        sub_part_keys = {"of_modifier", "of_head", "of_topic", "of_complement"}
-        sub_locks = {k: v for k, v in (locks or {}).items() if k in sub_part_keys}
+    of_object = _weighted_sample(obj_rows, 1, rng, obj_target, conn)[0]
+    remixed = False
+    remix_parts = {}
 
-        if sub_locks:
-            result = _try_remix(conn, rng, adjusted_tone_target, of_object, min_sim,
-                                locked_parts=sub_locks)
+    sub_part_keys = {"of_modifier", "of_head", "of_topic", "of_complement"}
+    sub_locks = {k: v for k, v in (locks or {}).items() if k in sub_part_keys}
+
+    if sub_locks:
+        result = _try_remix(conn, rng, adjusted_tone_target, of_object, min_sim,
+                            locked_parts=sub_locks)
+        if result:
+            of_object, remix_parts, remix_similarity = result
+            remixed = True
+    elif remix_prob > 0 and len(of_object.split()) >= 2:
+        should_remix = (rng or random).random() < remix_prob
+        if should_remix:
+            result = _try_remix(conn, rng, adjusted_tone_target, of_object, min_sim)
             if result:
                 of_object, remix_parts, remix_similarity = result
                 remixed = True
-        elif remix_prob > 0 and len(of_object.split()) >= 2:
-            should_remix = (rng or random).random() < remix_prob
-            if should_remix:
-                result = _try_remix(conn, rng, adjusted_tone_target, of_object, min_sim)
-                if result:
-                    of_object, remix_parts, remix_similarity = result
-                    remixed = True
 
-    # Resolve articles from corpus stats
+    return of_object, remixed, remix_parts, remix_similarity
+
+
+def _select_subtitle_parts(
+    conn: sqlite3.Connection,
+    candidates: GenerationCandidates,
+    rng: random.Random | None,
+    adjusted_tone_target: dict[str, float] | None,
+    remix_prob: float,
+    min_sim: float,
+    locks: dict[str, str] | None,
+) -> SelectedSubtitleParts:
+    list_target = adjusted_tone_target.get("list_item") if adjusted_tone_target else None
+    action_target = adjusted_tone_target.get("action_noun") if adjusted_tone_target else None
+    items = _pick_list_items(candidates.list_rows, rng, list_target, conn, locks)
+    action_noun = _pick_action_noun(candidates.action_rows, rng, action_target, conn, locks)
+    of_object, remixed, remix_parts, remix_similarity = _pick_of_object_and_remix(
+        conn, candidates.obj_rows, rng, adjusted_tone_target, remix_prob, min_sim, locks,
+    )
+    return SelectedSubtitleParts(
+        items=items,
+        action_noun=action_noun,
+        of_object=of_object,
+        remixed=remixed,
+        remix_parts=remix_parts,
+        remix_similarity=remix_similarity,
+    )
+
+
+def _resolve_articles(
+    conn: sqlite3.Connection,
+    action_noun: str,
+    of_object: str,
+    remixed: bool,
+    remix_parts: dict,
+) -> tuple[str, str]:
     ctx = _load_remix_context(conn)
     cfg = load_tuning_config(conn)
     of_min_freq = cfg.get("article_of_min_freq", 3.0)
@@ -866,32 +941,80 @@ def generate_subtitle(
             of_object, ctx.get("article_stats_of", {}), of_min_freq,
         )
 
-    # Correct a/an using phonetic analysis
     action_article = _fix_a_an(action_article, action_noun)
     if of_article:
         of_article = _fix_a_an(of_article, of_object)
+    return action_article, of_article
 
-    # Assemble raw text, then title-case once
+
+def _assemble_generated_subtitle(
+    parts: SelectedSubtitleParts,
+    action_article: str,
+    of_article: str,
+) -> GeneratedSubtitle:
     of_prefix = f"{of_article} " if of_article else ""
-    text = f"{items[0]}, {items[1]}, and {action_article} {action_noun} of {of_prefix}{of_object}"
-    text = _title_case(text)
-
-    # Title-case remix_parts for display
+    text = (
+        f"{parts.items[0]}, {parts.items[1]}, and "
+        f"{action_article} {parts.action_noun} of {of_prefix}{parts.of_object}"
+    )
+    remix_parts = parts.remix_parts
     if remix_parts:
         remix_parts = {k: _title_case(v) for k, v in remix_parts.items()}
 
     return GeneratedSubtitle(
-        text=text,
-        item1=_title_case(items[0]),
-        item2=_title_case(items[1]),
-        action_noun=_title_case(action_noun),
-        of_object=_title_case(of_object),
-        remixed=remixed,
+        text=_title_case(text),
+        item1=_title_case(parts.items[0]),
+        item2=_title_case(parts.items[1]),
+        action_noun=_title_case(parts.action_noun),
+        of_object=_title_case(parts.of_object),
+        remixed=parts.remixed,
         remix_parts=remix_parts,
-        remix_similarity=remix_similarity,
+        remix_similarity=parts.remix_similarity,
         of_article=of_article,
         action_article=action_article,
     )
+
+
+def generate_subtitle(
+    conn: sqlite3.Connection, seed: int | None = None,
+    tone_target: dict[str, float] | None = None,
+    remix_prob: float = 0.0, min_sim: float = 0.0,
+    locks: dict[str, str] | None = None,
+) -> GeneratedSubtitle:
+    """Generate one random subtitle in the 'X, Y, and the Z of W' pattern.
+
+    tone_target maps slot_type → log10 target score for filler biasing.
+    remix_prob: probability of remixing a multi-word of-object (0.0 = never, 1.0 = always).
+    min_sim: minimum cosine similarity for embedding coherence filter.
+    locks: optional dict mapping slot keys to locked values.
+        Supported keys: item1, item2, action_noun, of_object,
+        of_modifier, of_head, of_topic, of_complement.
+    """
+    rng = _make_rng(seed)
+    _validate_generation_locks(locks)
+
+    candidates = _load_generation_candidates(conn)
+    if not _has_enough_candidates(candidates, locks):
+        return _not_enough_fillers_subtitle()
+
+    adjusted_tone_target = _adjust_tone_targets(conn, tone_target)
+    parts = _select_subtitle_parts(
+        conn,
+        candidates,
+        rng,
+        adjusted_tone_target,
+        remix_prob,
+        min_sim,
+        locks,
+    )
+    action_article, of_article = _resolve_articles(
+        conn,
+        parts.action_noun,
+        parts.of_object,
+        parts.remixed,
+        parts.remix_parts,
+    )
+    return _assemble_generated_subtitle(parts, action_article, of_article)
 
 
 def _try_remix(

--- a/src/subtitle_generator/handlers.py
+++ b/src/subtitle_generator/handlers.py
@@ -10,7 +10,6 @@ import sqlite3
 from pathlib import Path
 
 from subtitle_generator.generate import (
-    TONE_TARGETS,
     GeneratedSubtitle,
     find_source,
     generate_subtitle,

--- a/src/subtitle_generator/jacket.py
+++ b/src/subtitle_generator/jacket.py
@@ -321,32 +321,45 @@ def _extract_section(content: str, section: str) -> str:
 DEFAULT_MODEL = DEFAULT_JACKET_MODEL
 
 
-async def _generate_jacket_async(
-    subtitle: str, model: str = DEFAULT_MODEL, timeout: float = 120.0,
+def _progress(msg: str, on_progress: Callable[[str], None] | None = None) -> None:
+    click.echo(f"  {msg}")
+    if on_progress:
+        on_progress(msg)
+
+
+def _prepare_jacket_prompt(
+    subtitle: str,
     conn: sqlite3.Connection | None = None,
-    tone_override: str | None = None, allowed_tiers: set[str] | None = None,
+    tone_override: str | None = None,
+    allowed_tiers: set[str] | None = None,
+    on_progress: Callable[[str], None] | None = None,
+) -> tuple[str, str, str]:
+    system_prompt, user_prompt, tone_tier = build_jacket_prompt(
+        subtitle, conn=conn, tone_override=tone_override, allowed_tiers=allowed_tiers,
+    )
+
+    if tone_override:
+        _progress("Tone: override", on_progress)
+    else:
+        _, score = compute_accessibility(subtitle, conn)
+        _progress(f"Tone: {tone_tier} (score: {score:.2f})", on_progress)
+
+    return system_prompt, user_prompt, tone_tier
+
+
+async def _generate_jacket_from_prompt_async(
+    subtitle: str,
+    system_prompt: str,
+    user_prompt: str,
+    model: str = DEFAULT_MODEL,
+    timeout: float = 120.0,
     on_progress: Callable[[str], None] | None = None,
 ) -> str:
     """Call the Copilot SDK to generate a full book jacket with validation and retry."""
     if not _HAS_COPILOT_SDK:
         raise RuntimeError("Copilot SDK not available. Use dry_run=true for prompt-only mode.")
 
-    def _progress(msg: str) -> None:
-        click.echo(f"  {msg}")
-        if on_progress:
-            on_progress(msg)
-
-    system_prompt, user_prompt, tone_tier = build_jacket_prompt(
-        subtitle, conn=conn, tone_override=tone_override, allowed_tiers=allowed_tiers,
-    )
-
-    if tone_override:
-        _progress("Tone: override")
-    else:
-        _, score = compute_accessibility(subtitle, conn)
-        _progress(f"Tone: {tone_tier} (score: {score:.2f})")
-
-    _progress(f"Connecting to {model}...")
+    _progress(f"Connecting to {model}...", on_progress)
 
     async with CopilotClient() as client:
         async with await client.create_session(
@@ -355,24 +368,24 @@ async def _generate_jacket_async(
             infinite_sessions={"enabled": False},
         ) as session:
             prompt = system_prompt + "\n\n---\n\n" + user_prompt
-            _progress("Generating jacket...")
+            _progress("Generating jacket...", on_progress)
 
             for attempt in range(1, MAX_RETRIES + 2):
                 result = await session.send_and_wait(prompt, timeout=timeout)
                 content = (result.data.content or "") if result and result.data else ""
 
                 if not content:
-                    _progress(f"Attempt {attempt}: empty response, retrying...")
+                    _progress(f"Attempt {attempt}: empty response, retrying...", on_progress)
                     continue
 
                 missing = _validate_jacket(content)
                 if not missing:
-                    _progress("Complete")
+                    _progress("Complete", on_progress)
                     return content
 
                 if attempt <= MAX_RETRIES:
                     missing_names = ", ".join(missing)
-                    _progress(f"Attempt {attempt}: format issues: {missing_names}, retrying...")
+                    _progress(f"Attempt {attempt}: format issues: {missing_names}, retrying...", on_progress)
                     prompt = (
                         f"Your previous response did not satisfy these required sections "
                         f"or format requirements: {missing_names}.\n"
@@ -383,10 +396,45 @@ async def _generate_jacket_async(
                         f"The subtitle is:\n\n{subtitle}"
                     )
                 else:
-                    _progress(f"Best effort after {attempt} attempts")
+                    _progress(f"Best effort after {attempt} attempts", on_progress)
                     return content
 
             return "(No valid response after retries)"
+
+
+async def _generate_jacket_async(
+    subtitle: str, model: str = DEFAULT_MODEL, timeout: float = 120.0,
+    conn: sqlite3.Connection | None = None,
+    tone_override: str | None = None, allowed_tiers: set[str] | None = None,
+    on_progress: Callable[[str], None] | None = None,
+) -> str:
+    system_prompt, user_prompt, _ = _prepare_jacket_prompt(
+        subtitle, conn=conn, tone_override=tone_override, allowed_tiers=allowed_tiers,
+        on_progress=on_progress,
+    )
+    return await _generate_jacket_from_prompt_async(
+        subtitle, system_prompt, user_prompt, model=model, timeout=timeout,
+        on_progress=on_progress,
+    )
+
+
+def generate_jacket_from_prompt(
+    subtitle: str,
+    system_prompt: str,
+    user_prompt: str,
+    model: str = DEFAULT_MODEL,
+    timeout: float = 120.0,
+    show_concept: bool = False,
+    on_progress: Callable[[str], None] | None = None,
+) -> str:
+    """Synchronous wrapper for jacket generation from a prebuilt prompt."""
+    content = asyncio.run(_generate_jacket_from_prompt_async(
+        subtitle, system_prompt, user_prompt, model=model, timeout=timeout,
+        on_progress=on_progress,
+    ))
+    if not show_concept:
+        content = _strip_internal_concept(content)
+    return content
 
 
 def _strip_internal_concept(content: str) -> str:
@@ -404,11 +452,11 @@ def generate_jacket(
     on_progress: Callable[[str], None] | None = None,
 ) -> str:
     """Synchronous wrapper for jacket generation. Returns markdown string."""
-    content = asyncio.run(_generate_jacket_async(
-        subtitle, model=model, timeout=timeout,
-        conn=conn, tone_override=tone_override, allowed_tiers=allowed_tiers,
+    system_prompt, user_prompt, _ = _prepare_jacket_prompt(
+        subtitle, conn=conn, tone_override=tone_override, allowed_tiers=allowed_tiers,
         on_progress=on_progress,
-    ))
-    if not show_concept:
-        content = _strip_internal_concept(content)
-    return content
+    )
+    return generate_jacket_from_prompt(
+        subtitle, system_prompt, user_prompt, model=model, timeout=timeout,
+        show_concept=show_concept, on_progress=on_progress,
+    )

--- a/src/subtitle_generator/jacket.py
+++ b/src/subtitle_generator/jacket.py
@@ -10,6 +10,7 @@ from collections.abc import Callable
 import click
 
 from subtitle_generator.config import load_tuning_config
+from subtitle_generator.parameter_state import DEFAULT_JACKET_MODEL
 
 try:
     from copilot import CopilotClient
@@ -317,7 +318,7 @@ def _extract_section(content: str, section: str) -> str:
     return match.group("body") if match else ""
 
 
-DEFAULT_MODEL = "gpt-5.4-mini"
+DEFAULT_MODEL = DEFAULT_JACKET_MODEL
 
 
 async def _generate_jacket_async(
@@ -340,13 +341,9 @@ async def _generate_jacket_async(
     )
 
     if tone_override:
-        _progress(f"Tone: override")
+        _progress("Tone: override")
     else:
         _, score = compute_accessibility(subtitle, conn)
-        cfg = load_tuning_config(conn)
-        pop_thresh = cfg["accessibility_threshold_pop"]
-        main_thresh = cfg["accessibility_threshold_mainstream"]
-        natural = "pop" if score > pop_thresh else ("mainstream" if score >= main_thresh else "niche")
         _progress(f"Tone: {tone_tier} (score: {score:.2f})")
 
     _progress(f"Connecting to {model}...")

--- a/src/subtitle_generator/parameter_state.py
+++ b/src/subtitle_generator/parameter_state.py
@@ -1,0 +1,208 @@
+"""Typed views over tunable parameters and model identifiers."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+
+from subtitle_generator.config import load_tuning_config
+
+
+DEFAULT_RATER_MODEL = "github_copilot/gpt-5.4-mini"
+DEFAULT_PROPOSER_MODEL = "github_copilot/gpt-5.4"
+DEFAULT_JACKET_MODEL = "gpt-5.4-mini"
+RESPONSES_ONLY_MODELS = frozenset({"gpt-5.4-mini", "gpt-5.4", "gpt-5.4-nano"})
+
+
+@dataclass(frozen=True)
+class SamplingParameters:
+    weighted_sample_spread: float
+    weighted_sample_bias_floor: float
+
+
+@dataclass(frozen=True)
+class PopularityParameters:
+    weight_spl: float
+    weight_ol: float
+    weight_goodreads: float
+    weight_nyt: float
+    weight_library: float
+    weight_frequency: float
+    exponent: float
+
+
+@dataclass(frozen=True)
+class PopularityBlendParameters:
+    base_weight_blend: float
+    tone_blend: float
+    classification_blend: float
+    missing_default: float
+
+
+@dataclass(frozen=True)
+class SlotMultiplierParameters:
+    list_item: float
+    action_noun: float
+    of_object: float
+
+
+@dataclass(frozen=True)
+class ArticleParameters:
+    of_min_freq: float
+    action_min_freq: float
+    remix_heuristic_threshold: float
+
+
+@dataclass(frozen=True)
+class RemixParameters:
+    reject_double_of: float
+
+
+@dataclass(frozen=True)
+class TierThresholdParameters:
+    center_pop: float
+    center_mainstream: float
+    center_niche: float
+    accessibility_pop: float
+    accessibility_mainstream: float
+
+
+@dataclass(frozen=True)
+class ToneTargets:
+    pop: dict[str, float]
+    mainstream: dict[str, float]
+    niche: dict[str, float]
+
+
+@dataclass(frozen=True)
+class RuntimeGenerationParameters:
+    sampling: SamplingParameters
+    popularity_blends: PopularityBlendParameters
+    slot_multipliers: SlotMultiplierParameters
+    article: ArticleParameters
+    remix: RemixParameters
+
+
+@dataclass(frozen=True)
+class ModelRegistry:
+    rater: str
+    proposer: str
+    jacket: str
+    responses_only: frozenset[str]
+
+
+def _cfg(conn: sqlite3.Connection | None = None) -> dict[str, float]:
+    return load_tuning_config(conn)
+
+
+def get_sampling_parameters(conn: sqlite3.Connection | None = None) -> SamplingParameters:
+    cfg = _cfg(conn)
+    return SamplingParameters(
+        weighted_sample_spread=cfg["weighted_sample_spread"],
+        weighted_sample_bias_floor=cfg["weighted_sample_bias_floor"],
+    )
+
+
+def get_popularity_parameters(conn: sqlite3.Connection | None = None) -> PopularityParameters:
+    cfg = _cfg(conn)
+    return PopularityParameters(
+        weight_spl=cfg["pop_weight_spl"],
+        weight_ol=cfg["pop_weight_ol"],
+        weight_goodreads=cfg["pop_weight_gr"],
+        weight_nyt=cfg["pop_weight_nyt"],
+        weight_library=cfg["pop_weight_library"],
+        weight_frequency=cfg["pop_weight_freq"],
+        exponent=cfg["pop_exponent"],
+    )
+
+
+def get_popularity_blend_parameters(
+    conn: sqlite3.Connection | None = None,
+) -> PopularityBlendParameters:
+    cfg = _cfg(conn)
+    return PopularityBlendParameters(
+        base_weight_blend=cfg["pop_base_weight_blend"],
+        tone_blend=cfg["pop_tone_blend"],
+        classification_blend=cfg["pop_classification_blend"],
+        missing_default=cfg["pop_missing_default"],
+    )
+
+
+def get_slot_multiplier_parameters(
+    conn: sqlite3.Connection | None = None,
+) -> SlotMultiplierParameters:
+    cfg = _cfg(conn)
+    return SlotMultiplierParameters(
+        list_item=cfg["pop_slot_mult_list_item"],
+        action_noun=cfg["pop_slot_mult_action_noun"],
+        of_object=cfg["pop_slot_mult_of_object"],
+    )
+
+
+def get_article_parameters(conn: sqlite3.Connection | None = None) -> ArticleParameters:
+    cfg = _cfg(conn)
+    return ArticleParameters(
+        of_min_freq=cfg["article_of_min_freq"],
+        action_min_freq=cfg["article_action_min_freq"],
+        remix_heuristic_threshold=cfg["article_remix_heuristic_threshold"],
+    )
+
+
+def get_remix_parameters(conn: sqlite3.Connection | None = None) -> RemixParameters:
+    cfg = _cfg(conn)
+    return RemixParameters(reject_double_of=cfg["remix_reject_double_of"])
+
+
+def get_tier_threshold_parameters(
+    conn: sqlite3.Connection | None = None,
+) -> TierThresholdParameters:
+    cfg = _cfg(conn)
+    return TierThresholdParameters(
+        center_pop=cfg["tier_center_pop"],
+        center_mainstream=cfg["tier_center_mainstream"],
+        center_niche=cfg["tier_center_niche"],
+        accessibility_pop=cfg["accessibility_threshold_pop"],
+        accessibility_mainstream=cfg["accessibility_threshold_mainstream"],
+    )
+
+
+def get_tone_targets(conn: sqlite3.Connection | None = None) -> ToneTargets:
+    cfg = _cfg(conn)
+    return ToneTargets(
+        pop={
+            "list_item": cfg["tone_target_pop_list_item"],
+            "action_noun": cfg["tone_target_pop_action_noun"],
+            "of_object": cfg["tone_target_pop_of_object"],
+        },
+        mainstream={
+            "list_item": cfg["tone_target_mainstream_list_item"],
+            "action_noun": cfg["tone_target_mainstream_action_noun"],
+            "of_object": cfg["tone_target_mainstream_of_object"],
+        },
+        niche={
+            "list_item": cfg["tone_target_niche_list_item"],
+            "action_noun": cfg["tone_target_niche_action_noun"],
+            "of_object": cfg["tone_target_niche_of_object"],
+        },
+    )
+
+
+def get_runtime_generation_parameters(
+    conn: sqlite3.Connection | None = None,
+) -> RuntimeGenerationParameters:
+    return RuntimeGenerationParameters(
+        sampling=get_sampling_parameters(conn),
+        popularity_blends=get_popularity_blend_parameters(conn),
+        slot_multipliers=get_slot_multiplier_parameters(conn),
+        article=get_article_parameters(conn),
+        remix=get_remix_parameters(conn),
+    )
+
+
+def get_model_registry() -> ModelRegistry:
+    return ModelRegistry(
+        rater=DEFAULT_RATER_MODEL,
+        proposer=DEFAULT_PROPOSER_MODEL,
+        jacket=DEFAULT_JACKET_MODEL,
+        responses_only=RESPONSES_ONLY_MODELS,
+    )

--- a/src/subtitle_generator/pipeline_validation.py
+++ b/src/subtitle_generator/pipeline_validation.py
@@ -1,0 +1,198 @@
+"""Read-only readiness checks for the subtitle generation pipeline."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+
+from subtitle_generator.config import ALL_TUNABLE_PARAMS
+from subtitle_generator.parameter_state import get_model_registry
+from subtitle_generator.remix_state import validate_remix_precompute_state
+from subtitle_generator.schema_contracts import validate_schema
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    stage: str
+    check: str
+    message: str
+
+
+@dataclass(frozen=True)
+class PipelineValidationReport:
+    issues: tuple[ValidationIssue, ...]
+
+    @property
+    def ok(self) -> bool:
+        return not self.issues
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    return conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (table,),
+    ).fetchone() is not None
+
+
+def _columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def _validate_parameter_config(conn: sqlite3.Connection) -> list[ValidationIssue]:
+    issues: list[ValidationIssue] = []
+    if not _table_exists(conn, "config"):
+        return [ValidationIssue(
+            stage="model_weight_state",
+            check="config",
+            message="model_weight_state: missing required table 'config'",
+        )]
+
+    config_columns = _columns(conn, "config")
+    if not {"key", "value"} <= config_columns:
+        return issues
+
+    for key, value in conn.execute("SELECT key, value FROM config").fetchall():
+        if key in ALL_TUNABLE_PARAMS:
+            try:
+                float(value)
+            except (TypeError, ValueError):
+                issues.append(ValidationIssue(
+                    stage="model_weight_state",
+                    check="config_value",
+                    message=f"model_weight_state: config key {key!r} is not numeric",
+                ))
+    return issues
+
+
+def _validate_model_registry(conn: sqlite3.Connection) -> list[ValidationIssue]:
+    issues: list[ValidationIssue] = []
+    registry = get_model_registry()
+    known_models = {registry.rater, registry.proposer, registry.jacket}
+    known_models.update(registry.responses_only)
+    if not registry.rater or not registry.proposer or not registry.jacket:
+        issues.append(ValidationIssue(
+            stage="model_weight_state",
+            check="model_registry",
+            message="model_weight_state: model registry contains an empty model id",
+        ))
+
+    if not _table_exists(conn, "config") or not {"key", "value"} <= _columns(conn, "config"):
+        return issues
+
+    for key, value in conn.execute("SELECT key, value FROM config").fetchall():
+        if key.endswith("_model") and value not in known_models:
+            issues.append(ValidationIssue(
+                stage="model_weight_state",
+                check="model_registry",
+                message=f"model_weight_state: unknown configured model id {value!r}",
+            ))
+    return issues
+
+
+def _validate_popularity_coverage(conn: sqlite3.Connection) -> list[ValidationIssue]:
+    if not _table_exists(conn, "slot_fillers"):
+        return [ValidationIssue(
+            stage="popularity_scoring",
+            check="coverage",
+            message="popularity_scoring: missing required table 'slot_fillers'",
+        )]
+
+    required_columns = {"slot_type", "mode", "popularity_score"}
+    actual_columns = _columns(conn, "slot_fillers")
+    if not required_columns <= actual_columns:
+        missing = ", ".join(sorted(required_columns - actual_columns))
+        return [ValidationIssue(
+            stage="popularity_scoring",
+            check="coverage",
+            message=f"popularity_scoring: slot_fillers is missing columns: {missing}",
+        )]
+
+    issues: list[ValidationIssue] = []
+    strict_count = conn.execute(
+        "SELECT COUNT(*) FROM slot_fillers WHERE mode = 'strict'"
+    ).fetchone()[0]
+    if strict_count == 0:
+        issues.append(ValidationIssue(
+            stage="popularity_scoring",
+            check="coverage",
+            message="popularity_scoring: no strict slot fillers are available",
+        ))
+        return issues
+
+    missing_scores = conn.execute(
+        """
+        SELECT COUNT(*) FROM slot_fillers
+        WHERE mode = 'strict' AND popularity_score IS NULL
+        """
+    ).fetchone()[0]
+    if missing_scores:
+        issues.append(ValidationIssue(
+            stage="popularity_scoring",
+            check="coverage",
+            message=(
+                "popularity_scoring: "
+                f"{missing_scores} strict slot fillers lack popularity_score"
+            ),
+        ))
+
+    slot_counts = dict(conn.execute(
+        """
+        SELECT slot_type, COUNT(*) FROM slot_fillers
+        WHERE mode = 'strict'
+        GROUP BY slot_type
+        """
+    ).fetchall())
+    for slot_type in ("list_item", "action_noun", "of_object"):
+        if slot_counts.get(slot_type, 0) == 0:
+            issues.append(ValidationIssue(
+                stage="serving",
+                check="runtime_candidates",
+                message=f"serving: no strict {slot_type!r} candidates are available",
+            ))
+    return issues
+
+
+def _validate_serving_contracts() -> list[ValidationIssue]:
+    from subtitle_generator import handlers
+
+    issues: list[ValidationIssue] = []
+    for name in ("subtitle_to_dict", "handle_generate", "handle_jacket", "handle_rate"):
+        if not callable(getattr(handlers, name, None)):
+            issues.append(ValidationIssue(
+                stage="serving",
+                check="handler_contract",
+                message=f"serving: missing callable handlers.{name}",
+            ))
+    return issues
+
+
+def validate_pipeline(
+    conn: sqlite3.Connection,
+    expected_embedding_version: str = "2",
+) -> PipelineValidationReport:
+    """Validate pipeline readiness without mutating DB state or generating subtitles."""
+
+    issues: list[ValidationIssue] = []
+    issues.extend(
+        ValidationIssue(issue.stage, "schema", issue.message)
+        for issue in validate_schema(conn)
+    )
+    issues.extend(_validate_parameter_config(conn))
+    issues.extend(_validate_model_registry(conn))
+    issues.extend(
+        ValidationIssue(issue.stage, "remix_precompute", issue.message)
+        for issue in validate_remix_precompute_state(conn, expected_embedding_version)
+    )
+    issues.extend(_validate_popularity_coverage(conn))
+    issues.extend(_validate_serving_contracts())
+    return PipelineValidationReport(issues=tuple(issues))
+
+
+def format_validation_report(report: PipelineValidationReport) -> str:
+    if report.ok:
+        return "Pipeline validation passed."
+
+    lines = ["Pipeline validation failed:"]
+    for issue in report.issues:
+        lines.append(f"- [{issue.stage}/{issue.check}] {issue.message}")
+    return "\n".join(lines)

--- a/src/subtitle_generator/remix_state.py
+++ b/src/subtitle_generator/remix_state.py
@@ -1,0 +1,122 @@
+"""Remix precompute contracts and runtime context."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass, field
+from typing import Any
+
+
+REQUIRED_PRECOMPUTE_CONFIG_KEYS = frozenset({
+    "embedding_version",
+    "centroid_norm",
+    "avg_cross_sim_t1",
+    "avg_cross_sim_t2",
+})
+
+REQUIRED_REMIX_COLUMNS = frozenset({
+    "remix_type",
+    "remix_prep",
+    "remix_word_count",
+    "vector_sum",
+    "token_count",
+    "centroid_dot",
+    "norm_sq",
+})
+
+
+@dataclass(frozen=True)
+class RemixPrecomputeIssue:
+    stage: str
+    field: str
+    message: str
+
+
+@dataclass
+class RemixRuntimeContext:
+    precomputed: bool
+    config: dict[str, Any] = field(default_factory=dict)
+    article_stats_of: dict[str, dict[str, int]] = field(default_factory=dict)
+    article_stats_action: dict[str, dict[str, int]] = field(default_factory=dict)
+    centroid_norm: float | None = None
+    avg_cross_sim_t1: float | None = None
+    avg_cross_sim_t2: float | None = None
+    filler_scalars: dict[tuple[str, str], tuple[float, float]] = field(default_factory=dict)
+    nlp: Any = None
+    centroid: Any = None
+
+    def __getitem__(self, key: str) -> Any:
+        return getattr(self, key)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return getattr(self, key, default)
+
+
+def _table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def validate_remix_precompute_state(
+    conn: sqlite3.Connection,
+    expected_embedding_version: str,
+) -> list[RemixPrecomputeIssue]:
+    """Validate the DB state required for precomputed runtime remixing."""
+
+    issues: list[RemixPrecomputeIssue] = []
+
+    tables = {
+        row[0] for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table'"
+        )
+    }
+    if "config" not in tables:
+        return [RemixPrecomputeIssue(
+            stage="remix_precompute",
+            field="config",
+            message="remix_precompute: missing required table 'config'",
+        )]
+    if "slot_fillers" not in tables:
+        issues.append(RemixPrecomputeIssue(
+            stage="remix_precompute",
+            field="slot_fillers",
+            message="remix_precompute: missing required table 'slot_fillers'",
+        ))
+        return issues
+
+    config_values = dict(conn.execute("SELECT key, value FROM config").fetchall())
+    for key in sorted(REQUIRED_PRECOMPUTE_CONFIG_KEYS - config_values.keys()):
+        issues.append(RemixPrecomputeIssue(
+            stage="remix_precompute",
+            field=key,
+            message=f"remix_precompute: missing required config key {key!r}",
+        ))
+
+    actual_version = config_values.get("embedding_version")
+    if actual_version is not None and str(actual_version) != expected_embedding_version:
+        issues.append(RemixPrecomputeIssue(
+            stage="remix_precompute",
+            field="embedding_version",
+            message=(
+                "remix_precompute: embedding_version "
+                f"{actual_version!r} does not match expected {expected_embedding_version!r}"
+            ),
+        ))
+
+    columns = _table_columns(conn, "slot_fillers")
+    for column in sorted(REQUIRED_REMIX_COLUMNS - columns):
+        issues.append(RemixPrecomputeIssue(
+            stage="remix_precompute",
+            field=column,
+            message=f"remix_precompute: slot_fillers is missing column {column!r}",
+        ))
+
+    return issues
+
+
+def assert_remix_precompute_state(
+    conn: sqlite3.Connection,
+    expected_embedding_version: str,
+) -> None:
+    issues = validate_remix_precompute_state(conn, expected_embedding_version)
+    if issues:
+        raise RuntimeError("\n".join(issue.message for issue in issues))

--- a/src/subtitle_generator/schema_contracts.py
+++ b/src/subtitle_generator/schema_contracts.py
@@ -1,0 +1,155 @@
+"""SQLite schema contracts for pipeline stage readiness checks."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TableContract:
+    """Required columns for a table owned or consumed by a pipeline stage."""
+
+    stage: str
+    table: str
+    columns: frozenset[str]
+
+
+@dataclass(frozen=True)
+class SchemaIssue:
+    """A missing table or column reported with stage context."""
+
+    stage: str
+    table: str
+    column: str | None
+    message: str
+
+
+SCHEMA_CONTRACTS: tuple[TableContract, ...] = (
+    TableContract(
+        stage="source_ingestion",
+        table="subtitles",
+        columns=frozenset({
+            "id", "title", "subtitle", "lang", "lccn", "source_file", "isbn",
+        }),
+    ),
+    TableContract(
+        stage="internal_slots",
+        table="pattern_matches",
+        columns=frozenset({
+            "id", "subtitle_id", "title", "subtitle", "list_items_json",
+            "action_noun", "of_object", "of_article", "action_article",
+        }),
+    ),
+    TableContract(
+        stage="internal_slots",
+        table="slot_fillers",
+        columns=frozenset({
+            "id", "slot_type", "filler", "mode", "source_subtitle_id", "freq",
+            "pos_tag", "prep", "remix_type", "remix_prep", "remix_word_count",
+            "vector_sum", "token_count", "centroid_dot", "norm_sq",
+            "popularity_score", "popularity_level", "popularity_confidence",
+        }),
+    ),
+    TableContract(
+        stage="popularity_scoring",
+        table="popularity_data",
+        columns=frozenset({
+            "work_key", "spl_checkouts", "spl_years", "spl_earliest_pub_year",
+            "ol_edition_count", "checkouts_per_year", "editions_per_decade",
+            "gr_ratings_count", "gr_average_rating", "nyt_weeks_on_list",
+            "nyt_peak_rank", "library_appearances", "composite_score",
+        }),
+    ),
+    TableContract(
+        stage="model_weight_state",
+        table="config",
+        columns=frozenset({"key", "value"}),
+    ),
+    TableContract(
+        stage="tuning_feedback",
+        table="human_ratings",
+        columns=frozenset({
+            "id", "subtitle", "system_tone", "thumbs", "tone_override",
+            "free_text", "interpreted", "config_snapshot", "created_at",
+            "tags", "source",
+        }),
+    ),
+)
+
+MINI_DB_SCHEMA_CONTRACTS: tuple[TableContract, ...] = (
+    TableContract(
+        stage="serving_sources",
+        table="sources",
+        columns=frozenset({
+            "slot_filler_id", "title", "subtitle_text", "source_tag",
+        }),
+    ),
+)
+
+REQUIRED_TABLES_BY_STAGE: dict[str, tuple[str, ...]] = {
+    stage: tuple(contract.table for contract in SCHEMA_CONTRACTS if contract.stage == stage)
+    for stage in sorted({contract.stage for contract in SCHEMA_CONTRACTS})
+}
+
+
+def get_contract(table: str) -> TableContract:
+    """Return the schema contract for ``table``."""
+
+    for contract in SCHEMA_CONTRACTS:
+        if contract.table == table:
+            return contract
+    raise KeyError(f"No schema contract for table: {table}")
+
+
+def table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    """Return column names for ``table``, or an empty set if it is missing."""
+
+    return {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def validate_schema(
+    conn: sqlite3.Connection,
+    contracts: tuple[TableContract, ...] = SCHEMA_CONTRACTS,
+) -> list[SchemaIssue]:
+    """Validate required tables/columns and return stage-aware issues."""
+
+    issues: list[SchemaIssue] = []
+    existing_tables = {
+        row[0] for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table'"
+        )
+    }
+    for contract in contracts:
+        if contract.table not in existing_tables:
+            issues.append(SchemaIssue(
+                stage=contract.stage,
+                table=contract.table,
+                column=None,
+                message=(
+                    f"{contract.stage}: missing required table "
+                    f"{contract.table!r}"
+                ),
+            ))
+            continue
+
+        actual_columns = table_columns(conn, contract.table)
+        for column in sorted(contract.columns - actual_columns):
+            issues.append(SchemaIssue(
+                stage=contract.stage,
+                table=contract.table,
+                column=column,
+                message=(
+                    f"{contract.stage}: table {contract.table!r} is missing "
+                    f"required column {column!r}"
+                ),
+            ))
+    return issues
+
+
+def assert_schema_valid(conn: sqlite3.Connection) -> None:
+    """Raise ``RuntimeError`` with stage-aware messages when schema is invalid."""
+
+    issues = validate_schema(conn)
+    if issues:
+        raise RuntimeError("\n".join(issue.message for issue in issues))

--- a/src/subtitle_generator/serve.py
+++ b/src/subtitle_generator/serve.py
@@ -407,6 +407,7 @@ class _Handler(BaseHTTPRequestHandler):
         try:
             system_prompt, user_prompt, tone_tier = build_jacket_prompt(subtitle, conn=conn)
             prompt_text = f"{system_prompt}\n\n---\n\n{user_prompt}"
+            on_progress(f"Tone: {tone_tier}")
 
             result_text = generate_jacket_from_prompt(
                 subtitle, system_prompt, user_prompt, model=model,

--- a/src/subtitle_generator/serve.py
+++ b/src/subtitle_generator/serve.py
@@ -8,9 +8,7 @@ import asyncio
 import json
 import os
 import random
-import sqlite3
 import uuid
-from functools import partial
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -18,7 +16,6 @@ from pathlib import Path
 from subtitle_generator.generate import GeneratedSubtitle, generate_subtitle
 from subtitle_generator.handlers import (
     get_db as _get_db,
-    build_sources as _build_sources,
     handle_generate as _handle_generate,
     handle_health as _handle_health,
     handle_jacket as _handle_jacket,

--- a/src/subtitle_generator/serve.py
+++ b/src/subtitle_generator/serve.py
@@ -21,7 +21,7 @@ from subtitle_generator.handlers import (
     handle_jacket as _handle_jacket,
     handle_rate as _handle_rate,
 )
-from subtitle_generator.jacket import build_jacket_prompt, generate_jacket
+from subtitle_generator.jacket import build_jacket_prompt, generate_jacket_from_prompt
 
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 _WEB_DIR = _PROJECT_ROOT / "web"
@@ -408,8 +408,8 @@ class _Handler(BaseHTTPRequestHandler):
             system_prompt, user_prompt, tone_tier = build_jacket_prompt(subtitle, conn=conn)
             prompt_text = f"{system_prompt}\n\n---\n\n{user_prompt}"
 
-            result_text = generate_jacket(
-                subtitle, model=model, conn=conn,
+            result_text = generate_jacket_from_prompt(
+                subtitle, system_prompt, user_prompt, model=model,
                 on_progress=on_progress,
             )
 

--- a/src/subtitle_generator/slots.py
+++ b/src/subtitle_generator/slots.py
@@ -587,7 +587,7 @@ def _build_article_stats(
     of_with = sum(1 for arts in of_stats.values() if any(a for a in arts if a))
     act_with = sum(1 for arts in action_stats.values()
                    if any(a for a in arts if a and a != "the"))
-    click.echo(f"\nBuilding article statistics...")
+    click.echo("\nBuilding article statistics...")
     click.echo(f"  of_object: {of_with:,} fillers with articles ({len(of_stats):,} total)")
     click.echo(f"  action_noun: {act_with:,} fillers with non-\"the\" articles ({len(action_stats):,} total)")
 

--- a/src/subtitle_generator/tune.py
+++ b/src/subtitle_generator/tune.py
@@ -14,7 +14,6 @@ import json
 import pathlib
 import re
 import sqlite3
-import subprocess
 import sys
 
 import click
@@ -31,6 +30,12 @@ from subtitle_generator.eval_harness import (
     structured_completion,
 )
 from subtitle_generator.feedback import store_rating
+from subtitle_generator.tuning_state import (
+    ConfigChange,
+    apply_config_change,
+    record_decision,
+    revert_config_change,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -58,6 +63,28 @@ def _needs_repopulate(param: str) -> bool:
 def _needs_calibrate(param: str) -> bool:
     """Check if changing this param requires recalibrating thresholds/tier centers."""
     return param in _REPOPULATE_PARAMS or param in _CALIBRATE_ONLY_PARAMS
+
+
+def _proposal_change(
+    proposal: ParamProposal,
+    current_params: dict[str, float],
+    bounds: dict[str, tuple[float, float]],
+) -> tuple[ConfigChange, float | None]:
+    """Create a rollback-capable config change, applying bounds if present."""
+
+    new_value = proposal.new_value
+    clamped_from = None
+    if proposal.param in bounds:
+        lo, hi = bounds[proposal.param]
+        clamped = max(lo, min(hi, new_value))
+        if clamped != new_value:
+            clamped_from = new_value
+            new_value = clamped
+    return ConfigChange(
+        param=proposal.param,
+        old_value=current_params[proposal.param],
+        new_value=new_value,
+    ), clamped_from
 
 
 def _run_calibrate_thresholds(conn: sqlite3.Connection) -> None:
@@ -187,7 +214,7 @@ def _score_in_memory(conn: sqlite3.Connection):
     import time as _time
 
     t0 = _time.time()
-    data = _load_pop_data()
+    _load_pop_data()
     cfg = load_tuning_config(conn)
 
     w_spl = cfg.get("pop_weight_spl", 0.7)
@@ -271,8 +298,6 @@ def _score_in_memory(conn: sqlite3.Connection):
             composite = min(composite, 0.5)
 
         work_composites[work] = composite
-
-    t1 = _time.time()
 
     # Compute filler scores from in-memory composites (top-3 mean)
     filler_works, filler_freq = _load_filler_works(conn)
@@ -411,7 +436,7 @@ def _load_results_history(results_file: str, max_lines: int = 20) -> str:
         return "\n".join(lines)
     # Always include the header + any regime-change lines + last max_lines
     header = lines[0]
-    regime_lines = [l for l in lines[1:-max_lines] if "[regime change]" in l]
+    regime_lines = [line for line in lines[1:-max_lines] if "[regime change]" in line]
     recent = lines[-max_lines:]
     parts = [header] + regime_lines + recent
     return "\n".join(parts)
@@ -898,12 +923,12 @@ def review_ratings(
         "",
         "### Mismatch patterns:",
     ]
-    for (sys, felt), count in mismatch_directions.most_common():
-        summary_lines.append(f"  target={sys} -> felt={felt}: {count}x")
+    for (system_tone, felt), count in mismatch_directions.most_common():
+        summary_lines.append(f"  target={system_tone} -> felt={felt}: {count}x")
     summary_lines.append("")
     summary_lines.append("### Mismatch examples:")
-    for sys, felt, sub in mismatch_examples:
-        summary_lines.append(f"  [{sys}->{felt}] {sub}")
+    for system_tone, felt, sub in mismatch_examples:
+        summary_lines.append(f"  [{system_tone}->{felt}] {sub}")
     if tag_counts:
         summary_lines.append("")
         summary_lines.append(f"### Quality tags: {dict(tag_counts.most_common())}")
@@ -1182,19 +1207,16 @@ scores — treat those results as unreliable.
             )
             continue
 
-        old_value = current_params[proposal.param]
-        new_value = proposal.new_value
+        change, clamped_from = _proposal_change(proposal, current_params, bounds)
+        old_value = change.old_value
+        new_value = change.new_value
 
-        # Clamp to bounds
-        if proposal.param in bounds:
+        if clamped_from is not None:
             lo, hi = bounds[proposal.param]
-            clamped = max(lo, min(hi, new_value))
-            if clamped != new_value:
-                click.echo(
-                    f"  ! clamping {proposal.param} "
-                    f"{new_value} -> {clamped} (bounds [{lo}, {hi}])"
-                )
-                new_value = clamped
+            click.echo(
+                f"  ! clamping {proposal.param} "
+                f"{clamped_from} -> {new_value} (bounds [{lo}, {hi}])"
+            )
 
         click.echo(
             f"  proposal: {proposal.param} {old_value} -> {new_value}"
@@ -1210,13 +1232,7 @@ scores — treat those results as unreliable.
             )
             continue
 
-        # Apply the change
-        conn.execute(
-            "INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)",
-            (proposal.param, str(new_value)),
-        )
-        conn.commit()
-        invalidate_config_cache()
+        apply_config_change(conn, change)
 
         # Re-run populate-popularity if this is a weight/exponent param
         if _needs_repopulate(proposal.param):
@@ -1224,16 +1240,7 @@ scores — treat those results as unreliable.
                 _run_repopulate(conn)
             except RuntimeError:
                 click.echo("  -> SKIP (repopulate failed)\n")
-                # Revert the config change
-                if old_value == ALL_TUNABLE_PARAMS[proposal.param]:
-                    conn.execute("DELETE FROM config WHERE key = ?", (proposal.param,))
-                else:
-                    conn.execute(
-                        "INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)",
-                        (proposal.param, str(old_value)),
-                    )
-                conn.commit()
-                invalidate_config_cache()
+                revert_config_change(conn, change)
                 _append_result(
                     results_file, i, proposal.param, old_value, new_value,
                     quality, separation, current_score,
@@ -1251,6 +1258,8 @@ scores — treat those results as unreliable.
         )
 
         delta = new_score - current_score
+        before_scores = (quality, separation, current_score)
+        after_scores = (new_quality, new_separation, new_score)
 
         if new_score > current_score:
             status = "keep"
@@ -1276,18 +1285,7 @@ scores — treat those results as unreliable.
                 click.echo(f"  [snapshot] new best composite {current_score:.4f} saved")
         else:
             status = "discard"
-            # Revert: restore old value or remove if it was a default
-            if old_value == ALL_TUNABLE_PARAMS[proposal.param]:
-                conn.execute(
-                    "DELETE FROM config WHERE key = ?", (proposal.param,)
-                )
-            else:
-                conn.execute(
-                    "INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)",
-                    (proposal.param, str(old_value)),
-                )
-            conn.commit()
-            invalidate_config_cache()
+            revert_config_change(conn, change)
             # Restore old filler scores in memory (no full DB write needed)
             if _needs_repopulate(proposal.param):
                 _run_repopulate(conn)
@@ -1300,10 +1298,18 @@ scores — treat those results as unreliable.
             )
             click.echo(f"  -> DISCARD ({delta:+.3f})\n")
 
+        decision = record_decision(
+            change=change,
+            reasoning=proposal.reasoning,
+            status=status,
+            before=before_scores,
+            after=after_scores,
+        )
         _append_result(
-            results_file, i, proposal.param, old_value, new_value,
-            new_quality, new_separation, new_score,
-            status, proposal.reasoning,
+            results_file, i, decision.change.param,
+            decision.change.old_value, decision.change.new_value,
+            decision.quality_after, decision.separation_after,
+            decision.composite_after, decision.status, decision.reasoning,
         )
 
     final_params = load_tuning_config(conn)

--- a/src/subtitle_generator/tuning_state.py
+++ b/src/subtitle_generator/tuning_state.py
@@ -1,0 +1,74 @@
+"""State records and config mutation helpers for tuning."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+
+from subtitle_generator.config import ALL_TUNABLE_PARAMS, invalidate_config_cache
+
+
+@dataclass(frozen=True)
+class ConfigChange:
+    """A proposed config mutation with enough state to roll back."""
+
+    param: str
+    old_value: float
+    new_value: float
+
+
+@dataclass(frozen=True)
+class ProposalDecision:
+    """Evaluation outcome for a proposed tuning change."""
+
+    change: ConfigChange
+    reasoning: str
+    status: str
+    quality_before: float
+    separation_before: float
+    composite_before: float
+    quality_after: float
+    separation_after: float
+    composite_after: float
+
+
+def write_config_param(conn: sqlite3.Connection, param: str, value: float) -> None:
+    """Persist a config value, deleting rows that match the default."""
+
+    if value == ALL_TUNABLE_PARAMS[param]:
+        conn.execute("DELETE FROM config WHERE key = ?", (param,))
+    else:
+        conn.execute(
+            "INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)",
+            (param, str(value)),
+        )
+    conn.commit()
+    invalidate_config_cache()
+
+
+def apply_config_change(conn: sqlite3.Connection, change: ConfigChange) -> None:
+    write_config_param(conn, change.param, change.new_value)
+
+
+def revert_config_change(conn: sqlite3.Connection, change: ConfigChange) -> None:
+    write_config_param(conn, change.param, change.old_value)
+
+
+def record_decision(
+    change: ConfigChange,
+    reasoning: str,
+    status: str,
+    before: tuple[float, float, float],
+    after: tuple[float, float, float],
+) -> ProposalDecision:
+    return ProposalDecision(
+        change=change,
+        reasoning=reasoning,
+        status=status,
+        quality_before=before[0],
+        separation_before=before[1],
+        composite_before=before[2],
+        quality_after=after[0],
+        separation_after=after[1],
+        composite_after=after[2],
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+"""Pytest collection settings for unit/characterization tests."""
+
+# Browser e2e scripts expect a running local server and are invoked via
+# scripts/run-local-e2e.ps1, not by the unit-test pytest run.
+collect_ignore = ["test_e2e.py", "test_e2e_spot_check.py"]

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -3,9 +3,8 @@
 Run:  uv run python tests/test_articles.py
 """
 
-import json
-import sqlite3
 import sys
+import re
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
@@ -114,8 +113,6 @@ def test_infer_deterministic():
 # ---------------------------------------------------------------------------
 # Article stripping in extraction (regex-based)
 # ---------------------------------------------------------------------------
-
-import re
 
 _ARTICLE_RE = re.compile(r"^(a|an|the)\s+", re.IGNORECASE)
 
@@ -243,7 +240,6 @@ def test_double_of_non_of_prep():
 # ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
-    import inspect
     test_fns = [obj for name, obj in globals().items()
                 if name.startswith("test_") and callable(obj)]
     for fn in test_fns:

--- a/tests/test_e2e_spot_check.py
+++ b/tests/test_e2e_spot_check.py
@@ -72,7 +72,7 @@ async def test():
         # Verify rate request was sent
         assert len(rate_requests) == 1, f"Expected 1 rate request, got {len(rate_requests)}"
         assert rate_requests[0].get("felt_tier") == "pop", f"Expected felt_tier=pop, got {rate_requests[0]}"
-        print(f"  PASS: rated as pop, reveal shown")
+        print("  PASS: rated as pop, reveal shown")
 
         # ── TEST 4: Advance with Next button ──
         print("TEST 4: Click Next to advance")
@@ -83,7 +83,7 @@ async def test():
         )
         progress = await page.locator('[data-testid="progress-text"]').text_content()
         assert "2 / 3" in progress, f"Expected '2 / 3', got: {progress}"
-        print(f"  PASS: advanced to item 2")
+        print("  PASS: advanced to item 2")
 
         # ── TEST 5: Keyboard shortcut (press 'n' for niche) ──
         print("TEST 5: Keyboard shortcut (n for niche)")
@@ -95,7 +95,7 @@ async def test():
         )
         assert len(rate_requests) == 1, f"Expected 1 rate request, got {len(rate_requests)}"
         assert rate_requests[0].get("felt_tier") == "niche", f"Expected felt_tier=niche, got {rate_requests[0]}"
-        print(f"  PASS: rated as niche via keyboard")
+        print("  PASS: rated as niche via keyboard")
 
         # ── TEST 6: Toggle tags during reveal ──
         print("TEST 6: Toggle tags during reveal")
@@ -107,7 +107,7 @@ async def test():
         # Toggle off
         await page.keyboard.press("f")
         funny_class = await funny_btn.get_attribute("class")
-        assert "active" not in funny_class, f"Expected funny tag inactive after toggle"
+        assert "active" not in funny_class, "Expected funny tag inactive after toggle"
         # Toggle on again for the submission
         await page.locator('[data-testid="tag-funny"]').click()
         await page.keyboard.press("i")
@@ -118,7 +118,7 @@ async def test():
         realistic_btn = page.locator('[data-testid="tag-realistic"]')
         realistic_class = await realistic_btn.get_attribute("class")
         assert "active" in realistic_class, f"Expected realistic tag active, got class: {realistic_class}"
-        print(f"  PASS: tags toggle correctly")
+        print("  PASS: tags toggle correctly")
 
         # Advance to next
         await page.keyboard.press("Enter")
@@ -139,7 +139,7 @@ async def test():
         assert rate_requests[0].get("skipped") is True, f"Expected skipped=true, got {rate_requests[0]}"
         skip_text = await page.locator('[data-testid="reveal-skip"]').text_content()
         assert "Skipped" in skip_text, f"Expected skip reveal, got: {skip_text}"
-        print(f"  PASS: skipped, reveal shows target")
+        print("  PASS: skipped, reveal shows target")
 
         # Advance — should go to summary
         await page.keyboard.press("Enter")
@@ -165,7 +165,7 @@ async def test():
         )
         progress = await page.locator('[data-testid="progress-text"]').text_content()
         assert "1 / 3" in progress, f"Expected '1 / 3' after load more, got: {progress}"
-        print(f"  PASS: new batch loaded, progress reset")
+        print("  PASS: new batch loaded, progress reset")
 
         # ── TEST 10: Keyboard hints visible ──
         print("TEST 10: Keyboard hints")
@@ -173,7 +173,7 @@ async def test():
         assert await hints.is_visible(), "Keyboard hints not visible"
         hints_text = await hints.text_content()
         assert "Pop" in hints_text and "Mainstream" in hints_text, f"Missing hint text: {hints_text}"
-        print(f"  PASS: keyboard hints visible")
+        print("  PASS: keyboard hints visible")
 
         # ── TEST 11: Back link ──
         print("TEST 11: Back link")
@@ -181,7 +181,7 @@ async def test():
         assert await back_link.is_visible(), "No back link"
         href = await back_link.get_attribute("href")
         assert href == "/", f"Back link should go to /, got: {href}"
-        print(f"  PASS: back link present")
+        print("  PASS: back link present")
 
         print()
         print(f"ALL 11 TESTS PASSED ({BASE_URL})")

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -283,7 +283,7 @@ def test_robot_grader_batch():
 
 def test_cli_review_mock():
     """Test _prompt_review with mocked click.prompt using robot grader."""
-    from subtitle_generator.feedback import ensure_ratings_table, get_summary
+    from subtitle_generator.feedback import ensure_ratings_table
 
     conn = make_test_db()
     ensure_ratings_table(conn)

--- a/tests/test_pipeline_characterization.py
+++ b/tests/test_pipeline_characterization.py
@@ -1,0 +1,813 @@
+"""Characterization coverage for the current pipeline contracts.
+
+These tests freeze observable behavior and state for the first redesign pass.
+They intentionally avoid changing production code or asserting unseeded random
+subtitle text byte-for-byte.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+EXPECTED_TUNABLE_PARAMS = {
+    "weighted_sample_spread": 0.4,
+    "weighted_sample_bias_floor": 0.05,
+    "tone_target_pop_list_item": 0.78,
+    "tone_target_pop_action_noun": 0.78,
+    "tone_target_pop_of_object": 0.78,
+    "tone_target_mainstream_list_item": 0.3,
+    "tone_target_mainstream_action_noun": 0.3,
+    "tone_target_mainstream_of_object": 0.3,
+    "tone_target_niche_list_item": 0.16,
+    "tone_target_niche_action_noun": 0.16,
+    "tone_target_niche_of_object": 0.16,
+    "sample_tone_spread": 0.6,
+    "tier_center_pop": 0.78,
+    "tier_center_mainstream": 0.3,
+    "tier_center_niche": 0.16,
+    "accessibility_threshold_pop": 0.6,
+    "accessibility_threshold_mainstream": 0.3,
+    "article_of_min_freq": 1.0,
+    "article_action_min_freq": 1.0,
+    "article_remix_heuristic_threshold": 0.6,
+    "remix_reject_double_of": 1.0,
+    "pop_weight_spl": 0.7,
+    "pop_weight_ol": 0.3,
+    "pop_weight_gr": 0.2,
+    "pop_weight_nyt": 0.1,
+    "pop_weight_library": 0.05,
+    "pop_weight_freq": 0.0,
+    "pop_exponent": 1.2,
+    "pop_base_weight_blend": 0.5,
+    "pop_tone_blend": 0.5,
+    "pop_classification_blend": 0.9,
+    "pop_missing_default": 0.1,
+    "pop_slot_mult_list_item": 0.8,
+    "pop_slot_mult_action_noun": 0.9,
+    "pop_slot_mult_of_object": 1.0,
+}
+
+
+def _columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def _insert_runtime_config(conn: sqlite3.Connection) -> None:
+    values = {
+        "embedding_version": "2",
+        "centroid_norm": "1.0",
+        "avg_cross_sim_t1": "0.1",
+        "avg_cross_sim_t2": "0.1",
+        "article_stats_action_noun": json.dumps(
+            {"making": {"the": 5}, "pursuit": {"the": 5}}
+        ),
+        "article_stats_of_object": json.dumps(
+            {"modern life": {"": 5}, "happiness": {"": 5}, "empire": {"the": 5}}
+        ),
+    }
+    conn.executemany("INSERT OR REPLACE INTO config VALUES (?, ?)", values.items())
+
+
+def _load_populate_popularity_module():
+    pop_spec = importlib.util.spec_from_file_location(
+        "populate_popularity", ROOT / "data" / "populate_popularity.py"
+    )
+    assert pop_spec is not None and pop_spec.loader is not None
+    populate_popularity = importlib.util.module_from_spec(pop_spec)
+    sys.modules[pop_spec.name] = populate_popularity
+    pop_spec.loader.exec_module(populate_popularity)
+    return populate_popularity
+
+
+def make_runtime_db(path: Path | None = None) -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:" if path is None else str(path))
+    conn.execute(
+        """
+        CREATE TABLE config (
+            key TEXT PRIMARY KEY,
+            value TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE slot_fillers (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            slot_type TEXT NOT NULL,
+            filler TEXT NOT NULL,
+            mode TEXT NOT NULL DEFAULT 'strict',
+            source_subtitle_id INTEGER,
+            freq INTEGER NOT NULL DEFAULT 1,
+            pos_tag TEXT,
+            prep TEXT,
+            remix_type TEXT,
+            remix_prep TEXT,
+            remix_word_count INTEGER,
+            vector_sum BLOB,
+            token_count INTEGER,
+            centroid_dot REAL,
+            norm_sq REAL,
+            popularity_score REAL,
+            UNIQUE(slot_type, filler)
+        )
+        """
+    )
+    _insert_runtime_config(conn)
+    rows = [
+        ("list_item", "race", 10, 1.0),
+        ("list_item", "power", 10, 1.0),
+        ("list_item", "history", 10, 1.0),
+        ("action_noun", "making", 10, 1.0),
+        ("action_noun", "pursuit", 10, 1.0),
+        ("of_object", "modern life", 10, 1.0),
+        ("of_object", "happiness", 10, 1.0),
+        ("of_object", "empire", 10, 1.0),
+    ]
+    conn.executemany(
+        """
+        INSERT INTO slot_fillers (slot_type, filler, freq, popularity_score)
+        VALUES (?, ?, ?, ?)
+        """,
+        rows,
+    )
+    conn.commit()
+    return conn
+
+
+def test_observed_pipeline_schema_columns(tmp_path):
+    from subtitle_generator.extract import get_db
+    from subtitle_generator.extract_openlibrary import ensure_isbn_column
+    from subtitle_generator.feedback import ensure_ratings_table
+    from subtitle_generator.schema_contracts import validate_schema
+    from subtitle_generator.slots import ensure_slot_tables
+
+    populate_popularity = _load_populate_popularity_module()
+
+    conn = get_db(tmp_path / "subtitles.db")
+    ensure_isbn_column(conn)
+    ensure_slot_tables(conn)
+    populate_popularity.create_tables(conn)
+    ensure_ratings_table(conn)
+
+    assert _columns(conn, "subtitles") >= {
+        "id", "title", "subtitle", "lang", "lccn", "source_file", "isbn",
+    }
+    assert _columns(conn, "pattern_matches") >= {
+        "id", "subtitle_id", "title", "subtitle", "list_items_json",
+        "action_noun", "of_object", "of_article", "action_article",
+    }
+    assert _columns(conn, "slot_fillers") >= {
+        "id", "slot_type", "filler", "mode", "source_subtitle_id", "freq",
+        "pos_tag", "prep", "remix_type", "remix_prep", "remix_word_count",
+        "vector_sum", "token_count", "centroid_dot", "norm_sq",
+        "popularity_score", "popularity_level", "popularity_confidence",
+    }
+    assert _columns(conn, "popularity_data") >= {
+        "work_key", "spl_checkouts", "spl_years", "spl_earliest_pub_year",
+        "ol_edition_count", "checkouts_per_year", "editions_per_decade",
+        "gr_ratings_count", "gr_average_rating", "nyt_weeks_on_list",
+        "nyt_peak_rank", "library_appearances", "composite_score",
+    }
+    assert _columns(conn, "config") == {"key", "value"}
+    assert _columns(conn, "human_ratings") >= {
+        "id", "subtitle", "system_tone", "thumbs", "tone_override",
+        "free_text", "interpreted", "config_snapshot", "created_at",
+        "tags", "source",
+    }
+    assert validate_schema(conn) == []
+
+
+def test_work_level_popularity_scoring_is_testable_without_db_writes():
+    from subtitle_generator.parameter_state import PopularityParameters
+
+    pop = _load_populate_popularity_module()
+    data = pop.WorkLevelData(
+        work_spl={
+            "work-a": {"checkouts": 100, "years": 10, "pub_year": "2000"},
+            "work-c": {"checkouts": 1, "years": 1, "pub_year": "2001"},
+        },
+        work_ol={"work-a": 5, "work-b": 20, "work-c": 1},
+        work_gr={
+            "work-a": {"ratings_count": 50, "average_rating": 4.2},
+            "work-c": {"ratings_count": 1, "average_rating": 3.1},
+        },
+        work_ottawa={},
+        work_nyt={"work-a": {"weeks_on_list": 4, "peak_rank": 3}},
+        all_works={"work-a", "work-b", "work-c"},
+    )
+    percentiles = pop.build_percentile_models(data)
+    params = PopularityParameters(
+        weight_spl=0.7,
+        weight_ol=0.3,
+        weight_goodreads=0.2,
+        weight_nyt=0.1,
+        weight_library=0.05,
+        weight_frequency=0.0,
+        exponent=1.2,
+    )
+
+    demand_row = pop.score_work_popularity("work-a", data, percentiles, params)
+    ol_only_row = pop.score_work_popularity("work-b", data, percentiles, params)
+
+    assert demand_row.work_key == "work-a"
+    assert demand_row.spl_checkouts == 100
+    assert demand_row.spl_years == 10
+    assert demand_row.gr_ratings_count == 50
+    assert demand_row.nyt_weeks_on_list == 4
+    assert demand_row.composite_score > ol_only_row.composite_score
+    assert ol_only_row.composite_score <= 0.5
+
+
+def test_filler_scoring_workers_cover_top3_mean_and_fallback():
+    pop = _load_populate_popularity_module()
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(
+        """
+        CREATE TABLE slot_fillers (
+            id INTEGER PRIMARY KEY,
+            slot_type TEXT NOT NULL,
+            filler TEXT NOT NULL,
+            mode TEXT NOT NULL DEFAULT 'strict',
+            freq INTEGER NOT NULL DEFAULT 1,
+            popularity_score REAL,
+            popularity_level INTEGER,
+            popularity_confidence REAL
+        );
+        CREATE TABLE slot_filler_sources (
+            slot_filler_id INTEGER NOT NULL,
+            subtitle_id INTEGER NOT NULL
+        );
+        CREATE TABLE subtitles (
+            id INTEGER PRIMARY KEY,
+            isbn TEXT
+        );
+        CREATE TABLE isbn_aliases (
+            isbn TEXT PRIMARY KEY,
+            work_key TEXT
+        );
+        CREATE TABLE popularity_data (
+            work_key TEXT PRIMARY KEY,
+            composite_score REAL
+        );
+        INSERT INTO slot_fillers (id, slot_type, filler, freq)
+        VALUES
+            (1, 'list_item', 'future', 100),
+            (2, 'list_item', 'fallback', 99);
+        INSERT INTO subtitles (id, isbn)
+        VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd');
+        INSERT INTO slot_filler_sources VALUES
+            (1, 1), (1, 2), (1, 3), (1, 4);
+        INSERT INTO isbn_aliases VALUES
+            ('a', 'work-a'), ('b', 'work-b'), ('c', 'work-c'), ('d', 'work-d');
+        INSERT INTO popularity_data VALUES
+            ('work-a', 0.9), ('work-b', 0.7), ('work-c', 0.6), ('work-d', 0.1);
+        """
+    )
+
+    assert pop.update_level1_filler_scores(conn) == 1
+    top3_score = conn.execute(
+        "SELECT popularity_score FROM slot_fillers WHERE id = 1"
+    ).fetchone()[0]
+    assert abs(top3_score - ((0.9 + 0.7 + 0.6) / 3)) < 0.0001
+
+    assert pop.update_fallback_filler_scores(conn) == 1
+    fallback = conn.execute(
+        """
+        SELECT popularity_score, popularity_level, popularity_confidence
+        FROM slot_fillers
+        WHERE id = 2
+        """
+    ).fetchone()
+    assert abs(fallback[0] - 2.0) < 0.0001
+    assert fallback[1:] == (0, 0.0)
+
+
+def test_threshold_calibration_workers_cover_percentile_cutoffs():
+    pop = _load_populate_popularity_module()
+
+    rows = [(9, i / 100) for i in range(100)]
+    scores = pop.compute_classification_scores(rows, blend=1.0, pop_default=0.1)
+    calibration = pop.calibrate_threshold_values(scores)
+    params = calibration.as_config_values()
+
+    assert calibration.pop_threshold == 0.92
+    assert calibration.mainstream_threshold == 0.64
+    assert calibration.pop_count == 8
+    assert calibration.mainstream_count == 28
+    assert calibration.niche_count == 64
+    assert params["accessibility_threshold_pop"] == 0.92
+    assert params["tone_target_mainstream_of_object"] == params["tier_center_mainstream"]
+
+
+def test_schema_contract_validator_reports_stage_context(tmp_path):
+    from subtitle_generator.extract import get_db
+    from subtitle_generator.extract_openlibrary import ensure_isbn_column
+    from subtitle_generator.feedback import ensure_ratings_table
+    from subtitle_generator.schema_contracts import (
+        REQUIRED_TABLES_BY_STAGE,
+        assert_schema_valid,
+        validate_schema,
+    )
+    from subtitle_generator.slots import ensure_slot_tables
+
+    assert REQUIRED_TABLES_BY_STAGE["source_ingestion"] == ("subtitles",)
+    assert REQUIRED_TABLES_BY_STAGE["model_weight_state"] == ("config",)
+
+    conn = get_db(tmp_path / "partial.db")
+    ensure_isbn_column(conn)
+    ensure_slot_tables(conn)
+    ensure_ratings_table(conn)
+    issues = validate_schema(conn)
+
+    assert any(
+        issue.stage == "popularity_scoring"
+        and issue.table == "popularity_data"
+        and issue.column is None
+        for issue in issues
+    )
+
+    try:
+        assert_schema_valid(conn)
+    except RuntimeError as exc:
+        assert "popularity_scoring" in str(exc)
+        assert "popularity_data" in str(exc)
+    else:
+        raise AssertionError("partial schema should not validate")
+
+
+def test_current_model_ids_and_tunable_defaults_are_characterized():
+    from subtitle_generator.config import ALL_TUNABLE_PARAMS
+    from subtitle_generator.jacket import DEFAULT_MODEL
+    from subtitle_generator.parameter_state import get_model_registry
+
+    assert ALL_TUNABLE_PARAMS == EXPECTED_TUNABLE_PARAMS
+    assert DEFAULT_MODEL == "gpt-5.4-mini"
+    assert get_model_registry().rater == "github_copilot/gpt-5.4-mini"
+    assert get_model_registry().proposer == "github_copilot/gpt-5.4"
+    assert get_model_registry().jacket == "gpt-5.4-mini"
+    assert get_model_registry().responses_only == {
+        "gpt-5.4-mini", "gpt-5.4", "gpt-5.4-nano",
+    }
+
+
+def test_parameter_views_preserve_defaults_and_db_overrides():
+    from subtitle_generator.parameter_state import (
+        get_popularity_blend_parameters,
+        get_popularity_parameters,
+        get_runtime_generation_parameters,
+        get_slot_multiplier_parameters,
+        get_tier_threshold_parameters,
+        get_tone_targets,
+    )
+
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE config (key TEXT PRIMARY KEY, value TEXT)")
+    conn.execute("INSERT INTO config VALUES ('pop_weight_spl', '0.9')")
+    conn.execute("INSERT INTO config VALUES ('pop_classification_blend', '0.25')")
+    conn.execute("INSERT INTO config VALUES ('pop_slot_mult_of_object', '1.4')")
+    conn.commit()
+
+    popularity = get_popularity_parameters(conn)
+    blends = get_popularity_blend_parameters(conn)
+    runtime = get_runtime_generation_parameters(conn)
+
+    assert popularity.weight_spl == 0.9
+    assert popularity.weight_ol == EXPECTED_TUNABLE_PARAMS["pop_weight_ol"]
+    assert blends.classification_blend == 0.25
+    assert get_slot_multiplier_parameters(conn).of_object == 1.4
+    assert runtime.popularity_blends == blends
+    assert runtime.slot_multipliers.of_object == 1.4
+    assert get_tier_threshold_parameters(conn).accessibility_pop == 0.6
+    assert get_tone_targets(conn).pop["list_item"] == 0.78
+
+
+def test_seeded_generation_path_is_stable():
+    import subtitle_generator.generate as generate_module
+    from subtitle_generator.generate import generate_subtitle
+    from subtitle_generator.remix_state import RemixRuntimeContext
+
+    conn = make_runtime_db()
+    generate_module._remix_ctx = None
+    first = generate_subtitle(conn, seed=11, remix_prob=0.0)
+
+    generate_module._remix_ctx = None
+    second = generate_subtitle(conn, seed=11, remix_prob=0.0)
+
+    assert first == second
+    assert first.text == "Power, Race, and the Pursuit of Happiness"
+    assert first.item1 == "Power"
+    assert first.item2 == "Race"
+    assert first.action_noun == "Pursuit"
+    assert first.of_object == "Happiness"
+    assert first.remixed is False
+    assert first.remix_parts == {}
+    assert first.remix_similarity is None
+    assert first.action_article == "the"
+    assert first.of_article == ""
+    assert isinstance(generate_module._remix_ctx, RemixRuntimeContext)
+    assert generate_module._remix_ctx.precomputed is True
+
+
+def test_remix_precompute_validator_checks_version_and_columns():
+    import subtitle_generator.generate as generate_module
+    from subtitle_generator.generate import generate_subtitle
+    from subtitle_generator.remix_state import validate_remix_precompute_state
+
+    conn = make_runtime_db()
+    assert validate_remix_precompute_state(conn, expected_embedding_version="2") == []
+
+    conn.execute("UPDATE config SET value = '1' WHERE key = 'embedding_version'")
+    version_issues = validate_remix_precompute_state(conn, expected_embedding_version="2")
+    assert any(issue.field == "embedding_version" for issue in version_issues)
+
+    broken = sqlite3.connect(":memory:")
+    broken.execute("CREATE TABLE config (key TEXT PRIMARY KEY, value TEXT)")
+    _insert_runtime_config(broken)
+    broken.execute(
+        """
+        CREATE TABLE slot_fillers (
+            id INTEGER PRIMARY KEY,
+            slot_type TEXT NOT NULL,
+            filler TEXT NOT NULL,
+            mode TEXT NOT NULL DEFAULT 'strict',
+            freq INTEGER NOT NULL DEFAULT 1,
+            popularity_score REAL
+        )
+        """
+    )
+    column_issues = validate_remix_precompute_state(broken, expected_embedding_version="2")
+    assert any(issue.field == "centroid_dot" for issue in column_issues)
+
+    broken.executemany(
+        """
+        INSERT INTO slot_fillers (slot_type, filler, freq, popularity_score)
+        VALUES (?, ?, 1, 1.0)
+        """,
+        [
+            ("list_item", "race"),
+            ("list_item", "power"),
+            ("action_noun", "making"),
+            ("of_object", "happiness"),
+        ],
+    )
+    try:
+        generate_module._remix_ctx = None
+        generate_subtitle(broken, seed=1, remix_prob=0.0)
+    except RuntimeError as exc:
+        assert "slot_fillers is missing column" in str(exc)
+    else:
+        raise AssertionError("missing remix columns should fail before runtime usage")
+
+
+def test_handler_generate_payload_shape_with_locked_values(tmp_path, monkeypatch):
+    from subtitle_generator import handlers
+
+    db_path = tmp_path / "runtime.db"
+    conn = make_runtime_db(db_path)
+    conn.close()
+
+    monkeypatch.setattr(
+        handlers,
+        "get_db",
+        lambda db_path=None: sqlite3.connect(str(db_path or tmp_path / "runtime.db")),
+    )
+
+    status, body = handlers.handle_generate({
+        "locks": {
+            "item1": "race",
+            "item2": "power",
+            "action_noun": "making",
+            "of_object": "modern life",
+        },
+        "remix_prob": 0.0,
+        "min_sim": 0.0,
+    })
+
+    assert status == 200
+    assert set(body) == {
+        "text", "item1", "item2", "action_noun", "of_object", "remixed",
+        "remix_parts", "remix_similarity", "of_article", "action_article",
+        "sources",
+    }
+    assert body == {
+        "text": "Race, Power, and the Making of Modern Life",
+        "item1": "Race",
+        "item2": "Power",
+        "action_noun": "Making",
+        "of_object": "Modern Life",
+        "remixed": False,
+        "remix_parts": {},
+        "remix_similarity": None,
+        "of_article": "",
+        "action_article": "the",
+        "sources": {
+            "item1": {"title": None, "tag": None},
+            "item2": {"title": None, "tag": None},
+            "action_noun": {"title": None, "tag": None},
+            "of_object": {"title": None, "tag": None},
+        },
+    }
+
+
+def test_subtitle_to_dict_contract_is_stable():
+    from subtitle_generator.generate import GeneratedSubtitle
+    from subtitle_generator.handlers import subtitle_to_dict
+
+    sub = GeneratedSubtitle(
+        text="Race, Power, and the Making of Modern Life",
+        item1="Race",
+        item2="Power",
+        action_noun="Making",
+        of_object="Modern Life",
+        remixed=True,
+        remix_parts={"modifier": "Modern", "head": "Life"},
+        remix_similarity=0.42,
+        of_article="",
+        action_article="the",
+    )
+    sources = {"item1": {"title": "Book", "tag": "LOC"}}
+
+    assert subtitle_to_dict(sub, sources) == {
+        "text": "Race, Power, and the Making of Modern Life",
+        "item1": "Race",
+        "item2": "Power",
+        "action_noun": "Making",
+        "of_object": "Modern Life",
+        "remixed": True,
+        "remix_parts": {"modifier": "Modern", "head": "Life"},
+        "remix_similarity": 0.42,
+        "of_article": "",
+        "action_article": "the",
+        "sources": sources,
+    }
+
+
+def test_handle_generate_uses_configured_remix_defaults(tmp_path, monkeypatch):
+    from subtitle_generator import handlers
+    from subtitle_generator.generate import GeneratedSubtitle
+
+    db_path = tmp_path / "runtime.db"
+    conn = make_runtime_db(db_path)
+    conn.execute("INSERT OR REPLACE INTO config VALUES ('remix_calibrated_remix_prob', '0.33')")
+    conn.execute("INSERT OR REPLACE INTO config VALUES ('remix_calibrated_min_sim', '0.44')")
+    conn.commit()
+    conn.close()
+
+    observed = {}
+
+    def fake_generate_subtitle(conn, **kwargs):
+        observed.update(kwargs)
+        return GeneratedSubtitle(
+            text="Race, Power, and the Making of Modern Life",
+            item1="Race",
+            item2="Power",
+            action_noun="Making",
+            of_object="Modern Life",
+        )
+
+    monkeypatch.setattr(handlers, "get_db", lambda db_path=None: sqlite3.connect(str(tmp_path / "runtime.db")))
+    monkeypatch.setattr(handlers, "generate_subtitle", fake_generate_subtitle)
+
+    status, body = handlers.handle_generate({})
+
+    assert status == 200
+    assert body["text"] == "Race, Power, and the Making of Modern Life"
+    assert observed["remix_prob"] == 0.33
+    assert observed["min_sim"] == 0.44
+    assert observed["locks"] is None
+
+
+def test_handle_jacket_dry_run_contract(tmp_path, monkeypatch):
+    from subtitle_generator import handlers
+
+    db_path = tmp_path / "runtime.db"
+    conn = make_runtime_db(db_path)
+    conn.close()
+    monkeypatch.setattr(
+        handlers,
+        "get_db",
+        lambda db_path=None: sqlite3.connect(str(db_path or tmp_path / "runtime.db")),
+    )
+
+    status, body = handlers.handle_jacket({
+        "subtitle": "Race, Power, and the Making of Modern Life",
+        "dry_run": True,
+    })
+
+    assert status == 200
+    assert set(body) == {"prompt", "tone_tier", "result"}
+    assert "The subtitle is:" in body["prompt"]
+    assert body["tone_tier"] in {"pop", "mainstream", "niche"}
+    assert body["result"] is None
+
+
+def test_handle_rate_contract_persists_rating(tmp_path, monkeypatch):
+    from subtitle_generator import handlers
+
+    db_path = tmp_path / "runtime.db"
+    conn = make_runtime_db(db_path)
+    conn.close()
+    monkeypatch.setattr(
+        handlers,
+        "get_db",
+        lambda db_path=None: sqlite3.connect(str(db_path or tmp_path / "runtime.db")),
+    )
+
+    status, body = handlers.handle_rate({
+        "subtitle": "Race, Power, and the Making of Modern Life",
+        "thumbs": 1,
+        "tone_override": "pop",
+        "tags": ["interesting"],
+        "_source": "contract-test",
+    })
+
+    assert status == 200
+    assert body == {"id": 1, "status": "saved"}
+    conn = sqlite3.connect(db_path)
+    row = conn.execute(
+        "SELECT thumbs, tone_override, tags, source FROM human_ratings"
+    ).fetchone()
+    conn.close()
+    assert row == (1, "pop", '["interesting"]', "contract-test")
+
+
+def test_rating_config_snapshot_preserves_defaults_and_overrides():
+    from subtitle_generator.feedback import store_rating
+
+    conn = make_runtime_db()
+    conn.execute("INSERT OR REPLACE INTO config VALUES ('pop_tone_blend', '0.25')")
+    conn.commit()
+
+    row_id = store_rating(
+        conn,
+        "Power, Race, and the Pursuit of Happiness",
+        system_tone="pop",
+        thumbs=1,
+        tone_override="mainstream",
+        tags=["interesting", "realistic"],
+        source="characterization",
+    )
+
+    row = conn.execute(
+        """
+        SELECT config_snapshot, tags, source
+        FROM human_ratings
+        WHERE id = ?
+        """,
+        (row_id,),
+    ).fetchone()
+    snapshot = json.loads(row[0])
+
+    assert snapshot.keys() == EXPECTED_TUNABLE_PARAMS.keys()
+    assert snapshot["pop_tone_blend"] == 0.25
+    assert snapshot["weighted_sample_spread"] == 0.4
+    assert json.loads(row[1]) == ["interesting", "realistic"]
+    assert row[2] == "characterization"
+
+
+def test_tuning_config_change_applies_and_reverts_rows():
+    from subtitle_generator.tuning_state import (
+        ConfigChange,
+        apply_config_change,
+        revert_config_change,
+    )
+
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE config (key TEXT PRIMARY KEY, value TEXT)")
+    conn.execute("INSERT INTO config VALUES ('weighted_sample_spread', '0.7')")
+    conn.commit()
+
+    change = ConfigChange(
+        param="weighted_sample_spread",
+        old_value=0.7,
+        new_value=0.8,
+    )
+
+    apply_config_change(conn, change)
+    assert conn.execute(
+        "SELECT value FROM config WHERE key = 'weighted_sample_spread'"
+    ).fetchone()[0] == "0.8"
+
+    revert_config_change(conn, change)
+    assert conn.execute(
+        "SELECT value FROM config WHERE key = 'weighted_sample_spread'"
+    ).fetchone()[0] == "0.7"
+
+
+def test_tuning_revert_removes_default_override_row():
+    from subtitle_generator.config import ALL_TUNABLE_PARAMS
+    from subtitle_generator.tuning_state import ConfigChange, revert_config_change
+
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE config (key TEXT PRIMARY KEY, value TEXT)")
+    conn.execute("INSERT INTO config VALUES ('weighted_sample_spread', '0.9')")
+    conn.commit()
+
+    change = ConfigChange(
+        param="weighted_sample_spread",
+        old_value=ALL_TUNABLE_PARAMS["weighted_sample_spread"],
+        new_value=0.9,
+    )
+
+    revert_config_change(conn, change)
+    assert conn.execute(
+        "SELECT value FROM config WHERE key = 'weighted_sample_spread'"
+    ).fetchone() is None
+
+
+def test_tuning_proposal_decision_records_before_after_scores():
+    from subtitle_generator.tuning_state import ConfigChange, record_decision
+
+    decision = record_decision(
+        change=ConfigChange(
+            param="pop_tone_blend",
+            old_value=0.5,
+            new_value=0.6,
+        ),
+        reasoning="Increase tone influence.",
+        status="kept",
+        before=(7.5, 0.2, 7.9),
+        after=(7.6, 0.3, 8.2),
+    )
+
+    assert decision.change.param == "pop_tone_blend"
+    assert decision.status == "kept"
+    assert decision.quality_before == 7.5
+    assert decision.separation_after == 0.3
+
+
+def test_pipeline_validation_passes_for_minimal_ready_db(tmp_path):
+    from subtitle_generator.extract import get_db
+    from subtitle_generator.extract_openlibrary import ensure_isbn_column
+    from subtitle_generator.feedback import ensure_ratings_table
+    from subtitle_generator.pipeline_validation import validate_pipeline
+    from subtitle_generator.slots import ensure_slot_tables
+
+    populate_popularity = _load_populate_popularity_module()
+
+    conn = get_db(tmp_path / "ready.db")
+    ensure_isbn_column(conn)
+    ensure_slot_tables(conn)
+    populate_popularity.create_tables(conn)
+    ensure_ratings_table(conn)
+    _insert_runtime_config(conn)
+    conn.executemany(
+        """
+        INSERT INTO slot_fillers (
+            slot_type, filler, mode, freq, popularity_score,
+            popularity_level, popularity_confidence
+        )
+        VALUES (?, ?, 'strict', ?, ?, 'pop', 1.0)
+        """,
+        [
+            ("list_item", "race", 10, 1.0),
+            ("action_noun", "making", 10, 1.0),
+            ("of_object", "modern life", 10, 1.0),
+        ],
+    )
+    conn.commit()
+
+    report = validate_pipeline(conn)
+
+    assert report.ok
+    assert report.issues == ()
+
+
+def test_pipeline_validation_reports_readiness_failures_without_generation():
+    from subtitle_generator.pipeline_validation import validate_pipeline
+
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE config (key TEXT PRIMARY KEY, value TEXT)")
+    conn.execute(
+        """
+        CREATE TABLE slot_fillers (
+            slot_type TEXT,
+            mode TEXT,
+            popularity_score REAL
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO slot_fillers (slot_type, mode, popularity_score)
+        VALUES ('list_item', 'strict', NULL)
+        """
+    )
+    conn.commit()
+
+    report = validate_pipeline(conn)
+
+    messages = [issue.message for issue in report.issues]
+    assert not report.ok
+    assert any("missing required table 'subtitles'" in message for message in messages)
+    assert any("missing required config key 'embedding_version'" in message for message in messages)
+    assert any("strict slot fillers lack popularity_score" in message for message in messages)
+    assert any("no strict 'action_noun' candidates" in message for message in messages)

--- a/tests/test_pipeline_characterization.py
+++ b/tests/test_pipeline_characterization.py
@@ -639,6 +639,39 @@ def test_handle_rate_contract_persists_rating(tmp_path, monkeypatch):
     assert row == (1, "pop", '["interesting"]', "contract-test")
 
 
+def test_jacket_generation_uses_prepared_prompt_once(monkeypatch):
+    from subtitle_generator import jacket
+
+    calls = []
+    captured = {}
+
+    def fake_build_jacket_prompt(*args, **kwargs):
+        calls.append((args, kwargs))
+        return "system prompt", "user prompt", "mainstream"
+
+    async def fake_generate(subtitle, system_prompt, user_prompt, **kwargs):
+        captured.update({
+            "subtitle": subtitle,
+            "system_prompt": system_prompt,
+            "user_prompt": user_prompt,
+        })
+        return "## Internal Concept\nhidden\n\n## Title\nVisible"
+
+    monkeypatch.setattr(jacket, "build_jacket_prompt", fake_build_jacket_prompt)
+    monkeypatch.setattr(jacket, "_generate_jacket_from_prompt_async", fake_generate)
+
+    result = jacket.generate_jacket("Race, Power, and the Pursuit of Happiness")
+
+    assert len(calls) == 1
+    assert captured == {
+        "subtitle": "Race, Power, and the Pursuit of Happiness",
+        "system_prompt": "system prompt",
+        "user_prompt": "user prompt",
+    }
+    assert "## Internal Concept" not in result
+    assert "## Title" in result
+
+
 def test_rating_config_snapshot_preserves_defaults_and_overrides():
     from subtitle_generator.feedback import store_rating
 

--- a/tests/test_pipeline_characterization.py
+++ b/tests/test_pipeline_characterization.py
@@ -8,6 +8,7 @@ subtitle text byte-for-byte.
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
 import sqlite3
 import sys
@@ -670,6 +671,41 @@ def test_jacket_generation_uses_prepared_prompt_once(monkeypatch):
     }
     assert "## Internal Concept" not in result
     assert "## Title" in result
+
+
+def test_jacket_stream_reports_tone_progress(monkeypatch):
+    from subtitle_generator import serve
+
+    class DummyConn:
+        def close(self):
+            pass
+
+    def fake_build_jacket_prompt(subtitle, **kwargs):
+        assert subtitle == "Race, Power, and the Pursuit of Happiness"
+        assert isinstance(kwargs["conn"], DummyConn)
+        return "system prompt", "user prompt", "mainstream"
+
+    def fake_generate_jacket_from_prompt(*_args, on_progress=None, **_kwargs):
+        assert on_progress is not None
+        on_progress("Generating jacket...")
+        return "## Title\nVisible"
+
+    handler = object.__new__(serve._Handler)
+    handler.wfile = io.BytesIO()
+    handler.send_response = lambda _status: None
+    handler.send_header = lambda _name, _value: None
+    handler._cors_headers = lambda: None
+    handler.end_headers = lambda: None
+    monkeypatch.setattr(serve, "_get_db", lambda: DummyConn())
+    monkeypatch.setattr(serve, "build_jacket_prompt", fake_build_jacket_prompt)
+    monkeypatch.setattr(serve, "generate_jacket_from_prompt", fake_generate_jacket_from_prompt)
+
+    handler._handle_jacket_stream({"subtitle": "Race, Power, and the Pursuit of Happiness"})
+
+    body = handler.wfile.getvalue().decode("utf-8")
+    assert "event: progress\ndata: Tone: mainstream\n\n" in body
+    assert "event: progress\ndata: Generating jacket...\n\n" in body
+    assert "event: result\n" in body
 
 
 def test_rating_config_snapshot_preserves_defaults_and_overrides():

--- a/tests/test_popularity.py
+++ b/tests/test_popularity.py
@@ -200,7 +200,7 @@ def test_export_import_roundtrip():
                 f"Missing popularity_score column. Headers: {list(first_row.keys())}"
             )
             assert first_row["popularity_score"] != "", (
-                f"popularity_score should not be empty for Race"
+                "popularity_score should not be empty for Race"
             )
 
         # Import into mini DB
@@ -231,8 +231,8 @@ def test_jacket_accessibility_blend():
     )
     assert score0 > 0, f"Expected positive score, got {score0}"
 
-    # With blend=1, should use popularity only
-    conn.execute("INSERT OR REPLACE INTO config VALUES ('pop_tone_blend', '1.0')")
+    # With classification blend=1, should use popularity only
+    conn.execute("INSERT OR REPLACE INTO config VALUES ('pop_classification_blend', '1.0')")
     conn.commit()
     from subtitle_generator.config import invalidate_config_cache
     invalidate_config_cache()

--- a/uv.lock
+++ b/uv.lock
@@ -661,6 +661,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "isodate"
 version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1086,6 +1095,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "preshed"
 version = "3.0.13"
 source = { registry = "https://pypi.org/simple" }
@@ -1286,6 +1304,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e2/28/8cd999db1c4c6d7e855e7596bc17294829e95e818473afbb655cfa167dd0/pymarc-5.3.1.tar.gz", hash = "sha256:d289233d7298aeae45d976081710391cf21e754f73928132508b8adfe8ea0b49", size = 235395, upload-time = "2025-06-18T13:57:51.3Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ca/ba/058498db9945b4f0b1bbf9d2e3095d3c4c21934946953056b1a0751cc5a1/pymarc-5.3.1-py3-none-any.whl", hash = "sha256:3fcc09f9d51ef27c40f8d215e3219d0f3eb29716a0767e689c4923e38182ad73", size = 160259, upload-time = "2025-06-18T13:57:46.869Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -1525,6 +1559,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
 name = "setuptools"
 version = "82.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1687,6 +1746,13 @@ tune = [
     { name = "pydantic" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "ruff" },
+    { name = "ty" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "azure-data-tables", marker = "extra == 'deploy'", specifier = ">=12.5" },
@@ -1703,6 +1769,13 @@ requires-dist = [
     { name = "titlecase", specifier = ">=2.4" },
 ]
 provides-extras = ["tune", "deploy", "e2e"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "ruff", specifier = ">=0.15.12" },
+    { name = "ty", specifier = ">=0.0.32" },
+]
 
 [[package]]
 name = "thinc"
@@ -1824,6 +1897,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/7e/2aa791c9ae7b8cd5024cd4122e92267f664ca954cea3def3211919fa3c1f/ty-0.0.32.tar.gz", hash = "sha256:8743174c5f920f6700a4a0c9de140109189192ba16226884cd50095b43b8a45c", size = 5522294, upload-time = "2026-04-20T19:29:01.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/eb/1075dc6a49d7acbe2584ae4d5b410c41b1f177a5adcc567e09eca4c69000/ty-0.0.32-py3-none-linux_armv6l.whl", hash = "sha256:dacbc2f6cd698d488ae7436838ff929570455bf94bfa4d9fe57a630c552aff83", size = 10902959, upload-time = "2026-04-20T19:28:31.907Z" },
+    { url = "https://files.pythonhosted.org/packages/33/d2/c35fc8bc66e98d1ee9b0f8ed319bf743e450e1f1e997574b178fab75670f/ty-0.0.32-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:914bbc4f605ce2a9e2a78982e28fae1d3359a169d141f9dc3b4c7749cd5eca81", size = 10726172, upload-time = "2026-04-20T19:28:44.765Z" },
+    { url = "https://files.pythonhosted.org/packages/96/32/c827da3ca480456fb02d8cea68a2609273b6c220fea0be9a4c8d8470b86e/ty-0.0.32-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4787ac9fe1f86b1f3133f5c6732adbe2df5668b50c679ac6e2d98cd284da812f", size = 10163701, upload-time = "2026-04-20T19:28:27.005Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/9e/2734478fbdb90c160cb2813a3916a16a2af5c1e231f87d635f6131d781fb/ty-0.0.32-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8ea0a728af99fe40dd744cba6441a2404f80b7f4bde17aa6da393810af5ea57", size = 10656220, upload-time = "2026-04-20T19:29:03.814Z" },
+    { url = "https://files.pythonhosted.org/packages/44/9f/0007da2d35e424debe7e9f86ffbc1ab7f60983cfbc5f0411324ab2de5292/ty-0.0.32-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2850561f9b018ae33d7e5bbfa0ac414d3c518513edcffe43877dc9801446b9c5", size = 10696086, upload-time = "2026-04-20T19:28:46.829Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5e/ce5fd4ec803222ae3e69a76d2a2db2eed55e19f5b131702b9789ef45f93d/ty-0.0.32-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b5fa2fb3c614349ee211d36476b49d88c5ef79a687cdb91b2872ad023b94d2f8", size = 11184800, upload-time = "2026-04-20T19:28:42.57Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/46/ebcf67a5999421331214aac51a7464db42de2be15bbe929c612a3ed0b039/ty-0.0.32-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2b89969307ab2417d41c9be8059dd79feea577234e1e10d35132f5495e0d42c6", size = 11718718, upload-time = "2026-04-20T19:28:36.433Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2c/2141c86ed0ce0962b45cefb658a95e734f59759d47f20afdcd9c732910a1/ty-0.0.32-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b59868ede9b1d69a088f0d695df52a0061f95fa7baa1d5e0dc6fc9cf06e1334", size = 11346369, upload-time = "2026-04-20T19:28:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/da/ed6f772339cf29bd9a46def9d6db5084689eb574ee4d150ff704224c1ed8/ty-0.0.32-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8300caf35345498e9b9b03e550bba03cee8f5f5f8ab4c83c3b1ff1b7403b7d3a", size = 11280714, upload-time = "2026-04-20T19:28:51.516Z" },
+    { url = "https://files.pythonhosted.org/packages/da/9b/c6813987edf4816a40e0c8e408b555f97d3f267c7b3a1688c8bbdf65609c/ty-0.0.32-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:583c7094f4574b02f724db924f98b804d1387a0bd9405ecb5e078cc0f47fbcfb", size = 10638806, upload-time = "2026-04-20T19:28:29.651Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d4/0cefcbd2ad0f3d51762ccf58e652ec7da146eb6ae34f87228f6254bbb8be/ty-0.0.32-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e44ebe1bb4143a5628bc4db67ac0dfebe14594af671e4ee66f6f2e983da56501", size = 10726106, upload-time = "2026-04-20T19:29:06.3Z" },
+    { url = "https://files.pythonhosted.org/packages/32/ad/2c8a97f91f06311f4367400f7d13534bbda2522c73c99a3e4c0757dff9b8/ty-0.0.32-py3-none-musllinux_1_2_i686.whl", hash = "sha256:06f17ada3e069cba6148342ef88e9929156beca8473e8d4f101b68f66c75643e", size = 10872951, upload-time = "2026-04-20T19:28:34.077Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/68/42293f9248106dd51875120971a5cc6ea315c2c4dcfb8e59aa063aa0af26/ty-0.0.32-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e96e60fa556cec04f15d7ea62d2ceee5982bd389233e961ab9fd42304e278175", size = 11363334, upload-time = "2026-04-20T19:28:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/df/92/be9abf4d3e589ad5023e2ea965b93e204ec856420d46adf73c5c36c04678/ty-0.0.32-py3-none-win32.whl", hash = "sha256:2ff2ebb4986b24aebcf1444db7db5ca41b36086040e95eea9f8fb851c11e805c", size = 10260689, upload-time = "2026-04-20T19:28:56.541Z" },
+    { url = "https://files.pythonhosted.org/packages/14/61/dc86acea899349d2579cb8419aecedd83dc504d7d6a10df65eef546c8300/ty-0.0.32-py3-none-win_amd64.whl", hash = "sha256:ba7284a4a954b598c1b31500352b3ec1f89bff533825592b5958848226fdc7ee", size = 11255371, upload-time = "2026-04-20T19:28:39.917Z" },
+    { url = "https://files.pythonhosted.org/packages/43/01/beffec56d71ca25b343ede63adb076456b5b3e211f1c066452a44cd120b3/ty-0.0.32-py3-none-win_arm64.whl", hash = "sha256:7e10aadbdbda989a7d567ee6a37f8b98d4d542e31e3b190a2879fd581f75d658", size = 10658087, upload-time = "2026-04-20T19:28:59.286Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1721,7 +1721,7 @@ wheels = [
 
 [[package]]
 name = "subtitle-generator"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -197,9 +197,43 @@ export function createApp() {
           body,
         });
 
+        if (!response.ok) {
+          const message = await response.text();
+          throw new Error(message || response.statusText);
+        }
+        if (!response.body) {
+          throw new Error("Jacket generation returned no response body.");
+        }
+
         const reader = response.body.getReader();
         const decoder = new TextDecoder();
         let buffer = "";
+        let receivedTerminalEvent = false;
+        let terminalError = null;
+        const processEventBlock = (block) => {
+          if (!block.trim()) return;
+          let eventType = null;
+          const dataLines = [];
+          for (const line of block.split("\n")) {
+            if (line.startsWith("event: ")) eventType = line.slice(7);
+            else if (line.startsWith("data: ")) dataLines.push(line.slice(6));
+            else if (line.startsWith("data:")) dataLines.push(line.slice(5));
+          }
+          if (!eventType || dataLines.length === 0) return;
+          const data = dataLines.join("\n");
+          if (eventType === "progress") {
+            this.jacketProgress = data;
+          } else if (eventType === "result") {
+            const parsed = JSON.parse(data);
+            this.prompt = parsed.prompt;
+            this.toneTier = parsed.tone_tier;
+            this._setJacket(parsed.result);
+            receivedTerminalEvent = true;
+          } else if (eventType === "error") {
+            receivedTerminalEvent = true;
+            terminalError = new Error(data);
+          }
+        };
 
         while (true) {
           const { done, value } = await reader.read();
@@ -211,29 +245,19 @@ export function createApp() {
           const blocks = buffer.split("\n\n");
           buffer = blocks.pop(); // keep incomplete block
           for (const block of blocks) {
-            if (!block.trim()) continue;
-            let eventType = null;
-            const dataLines = [];
-            for (const line of block.split("\n")) {
-              if (line.startsWith("event: ")) eventType = line.slice(7);
-              else if (line.startsWith("data: ")) dataLines.push(line.slice(6));
-              else if (line.startsWith("data:")) dataLines.push(line.slice(5));
-            }
-            if (!eventType || dataLines.length === 0) continue;
-            const data = dataLines.join("\n");
-            if (eventType === "progress") {
-              this.jacketProgress = data;
-            } else if (eventType === "result") {
-              try {
-                const parsed = JSON.parse(data);
-                this.prompt = parsed.prompt;
-                this.toneTier = parsed.tone_tier;
-                this._setJacket(parsed.result);
-              } catch { /* partial JSON, wait for more */ }
-            } else if (eventType === "error") {
-              alert("Error: " + data);
-            }
+            processEventBlock(block);
+            if (receivedTerminalEvent) break;
           }
+          if (receivedTerminalEvent) {
+            await reader.cancel();
+            break;
+          }
+        }
+
+        if (buffer.trim() && !receivedTerminalEvent) processEventBlock(buffer);
+        if (terminalError) throw terminalError;
+        if (!receivedTerminalEvent) {
+          throw new Error("Jacket generation ended before returning a result.");
         }
       } catch (e) {
         alert("Failed: " + e.message);


### PR DESCRIPTION
## Summary

| Area | Change |
|---|---|
| Pipeline contracts | Adds schema/model/parameter/remix/tuning contracts plus validation coverage. |
| Runtime serving | Hardens streamed jacket generation so terminal result/error events complete reliably and tone progress is restored. |
| Documentation | Adds `docs/pipeline-end-to-end.md`, structured around Population, Serving, and Tuning boundaries with Mermaid diagrams and GitHub/VS Code-compatible math. |
| Release metadata | Bumps package version to `0.3.0`. |

## Validation

- `uv run pytest`
- `uv run ruff check`
- `uv run ty check`
- `git diff --check`
- Tri-review: Sonnet 4.6, GPT-5.4, Opus 4.7; all findings resolved

## Breaking changes

None.