### PR TITLE
Add Trove popularity source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-data/
+data/*
+!data/*.py
 *.mrc
 *.mrc.gz
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ uv run subtitle-gen extract                     # parse into SQLite
 uv run subtitle-gen download-ol                 # Open Library (~9.2 GB)
 uv run subtitle-gen extract-ol                  # parse + deduplicate
 uv run subtitle-gen build-slots                 # extract slot fillers
-uv run subtitle-gen download-popularity         # SPL, Goodreads, Ottawa, etc.
+uv run subtitle-gen download-popularity         # SPL, Goodreads, Ottawa, Trove, etc.
 uv run subtitle-gen populate-popularity         # compute composite scores
 uv run subtitle-gen precompute-vectors          # remix scalar/vector state
 uv run subtitle-gen validate-pipeline           # read-only readiness checks
@@ -65,7 +65,7 @@ The pipeline has explicit contract modules for the cross-stage state that feeds 
 |---|---|---|
 | Source ingestion | LOC MARC files and Open Library dumps | `subtitles` rows with ISBN/source metadata |
 | Slot extraction | Subtitle patterns plus spaCy validation | `pattern_matches` and strict `slot_fillers` candidates |
-| Popularity scoring | SPL, Open Library, Goodreads, NYT, Ottawa/library, and corpus frequency signals | `popularity_data.composite_score`, filler `popularity_score`, and calibrated threshold config values |
+| Popularity scoring | SPL, Open Library, Goodreads, NYT, Ottawa/library, Trove, and corpus frequency signals | `popularity_data.composite_score`, filler `popularity_score`, and calibrated threshold config values |
 | Remix precompute | Strict of-object fillers, spaCy vectors, article statistics | remix classifications, vector/scalar columns, embedding config keys |
 | Tuning | Generated samples, human ratings, LLM ratings, and strict proposal schemas | accepted config changes, rollback-capable proposal records, and rating snapshots |
 | Runtime/serving | Validated SQLite state and request parameters | `GeneratedSubtitle`, `subtitle_to_dict()`, CLI output, local HTTP, and Azure Functions payloads |
@@ -95,7 +95,7 @@ Model and weight state is grouped by purpose rather than treated as one loose di
 |---|---|
 | LLM models | rating model `github_copilot/gpt-5.4-mini`, proposal model `github_copilot/gpt-5.4`, jacket model `gpt-5.4-mini`, responses-only model family |
 | Sampling and tone | weighted sample spread, bias floor, tone targets, tier centers, accessibility thresholds |
-| Popularity | source weights for SPL/Open Library/Goodreads/NYT/library/frequency, exponent, blend defaults, slot multipliers |
+| Popularity | source weights for SPL/Open Library/Goodreads/NYT/library/Trove/frequency, exponent, blend defaults, slot multipliers |
 | Article and remix | article frequency thresholds, remix heuristic threshold, double-`of` rejection toggle, calibrated remix probability and similarity thresholds |
 
 ## Usage
@@ -111,6 +111,12 @@ uv run subtitle-gen jacket "sturgeon, caviar, and the geography of desire"
 ```
 
 Run `subtitle-gen <command> --help` for full options on any command.
+
+Trove Australia is an optional API-keyed popularity source. Set
+`TROVE_API_KEY` or pass `--trove-api-key`, then run a small resumable sample
+with `uv run subtitle-gen download-popularity --sources trove --trove-limit 100`.
+The lookup stores `holdingsCount` as Australian library breadth; physical copy
+counts are marked as proxies unless Trove exposes exact copy fields.
 
 ### Web app
 
@@ -245,7 +251,7 @@ Tuning goals and parameter bounds are documented in `tuning_goals.md`.
 | `build-db` | Build mini SQLite from CSV files (for CI) |
 | `patterns` | Show discovered subtitle patterns by frequency |
 | `slots` | Show available slot fillers |
-| `download-popularity` | Download all popularity data sources (SPL, Goodreads, Ottawa, NYT) |
+| `download-popularity` | Download all popularity data sources (SPL, Goodreads, Ottawa, NYT, Trove) |
 | `populate-popularity` | Build ISBN mappings + compute composite popularity scores |
 | `validate-pipeline` | Run read-only pipeline readiness checks |
 

--- a/data/canadian_library_stream.py
+++ b/data/canadian_library_stream.py
@@ -13,11 +13,9 @@ import csv
 import io
 import json
 import re
-import time
 from collections import defaultdict
 from pathlib import Path
 from urllib.error import HTTPError, URLError
-from urllib.parse import quote_plus
 from urllib.request import Request, urlopen
 
 USER_AGENT = "subtitle-generator/0.1 (research project)"
@@ -454,7 +452,7 @@ def main():
     print("\nPhase 3: Build lookup\n")
     if args.skip_isbn_lookup:
         lookup = build_lookup_no_isbn(all_entries)
-        print(f"  Built title/ISBN-keyed lookup (no OL resolution)")
+        print("  Built title/ISBN-keyed lookup (no OL resolution)")
     else:
         lookup, skipped = resolve_isbns(all_entries)
         print(f"  Skipped (no ISBN): {skipped:,}")

--- a/data/populate_popularity.py
+++ b/data/populate_popularity.py
@@ -22,12 +22,13 @@ OL_PATH = Path("data/ol_edition_lookup.json")
 GR_PATH = Path("data/goodreads_lookup.json")
 OTTAWA_PATH = Path("data/canadian_library_lookup.json")
 NYT_PATH = Path("data/nyt_bestseller_lookup.json")
+TROVE_PATH = Path("data/trove_holdings_lookup.json")
 
 # Ensure src is importable (for config access)
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-from subtitle_generator.config import load_tuning_config, ALL_TUNABLE_PARAMS
-from subtitle_generator.parameter_state import PopularityParameters
+from subtitle_generator.config import load_tuning_config, ALL_TUNABLE_PARAMS  # noqa: E402
+from subtitle_generator.parameter_state import PopularityParameters  # noqa: E402
 
 
 @dataclass
@@ -37,6 +38,7 @@ class WorkLevelData:
     work_gr: dict[str, dict]
     work_ottawa: dict[str, dict]
     work_nyt: dict[str, dict]
+    work_trove: dict[str, dict]
     all_works: set[str]
 
 
@@ -54,6 +56,10 @@ class WorkPopularityRow:
     nyt_weeks_on_list: int
     nyt_peak_rank: int | None
     library_appearances: int
+    trove_library_count: int
+    trove_holding_count: int
+    trove_copy_count: int
+    trove_copy_count_is_exact: int
     composite_score: float
 
     def as_db_tuple(self) -> tuple:
@@ -70,6 +76,10 @@ class WorkPopularityRow:
             self.nyt_weeks_on_list,
             self.nyt_peak_rank,
             self.library_appearances,
+            self.trove_library_count,
+            self.trove_holding_count,
+            self.trove_copy_count,
+            self.trove_copy_count_is_exact,
             self.composite_score,
         )
 
@@ -80,6 +90,7 @@ class PercentileModels:
     goodreads: Callable[[float], float]
     open_library: Callable[[float], float]
     library: Callable[[float], float]
+    trove: Callable[[float], float]
 
 
 @dataclass(frozen=True)
@@ -122,6 +133,10 @@ def create_tables(conn: sqlite3.Connection):
             nyt_weeks_on_list INTEGER DEFAULT 0,
             nyt_peak_rank INTEGER,
             library_appearances INTEGER DEFAULT 0,
+            trove_library_count INTEGER DEFAULT 0,
+            trove_holding_count INTEGER DEFAULT 0,
+            trove_copy_count INTEGER DEFAULT 0,
+            trove_copy_count_is_exact INTEGER DEFAULT 0,
             composite_score REAL
         )
     """)
@@ -197,6 +212,35 @@ def load_ottawa(conn: sqlite3.Connection, ottawa_isbn: dict) -> dict[str, dict]:
     return work_ottawa
 
 
+def load_trove(conn: sqlite3.Connection, trove_isbn: dict) -> dict[str, dict]:
+    """Map Trove Australia ISBN-keyed data to work_keys via isbn_aliases."""
+    work_trove: dict[str, dict] = {}
+    rows = conn.execute(
+        "SELECT isbn, work_key FROM isbn_aliases WHERE work_key IS NOT NULL"
+    ).fetchall()
+    isbn_to_work = {r[0]: r[1] for r in rows}
+
+    matched = 0
+    for isbn, data in trove_isbn.items():
+        work = isbn_to_work.get(isbn)
+        if work:
+            library_count = int(data.get("library_count", data.get("holding_count", 0)) or 0)
+            existing = work_trove.get(work)
+            if not existing or library_count > existing.get("library_count", 0):
+                work_trove[work] = {
+                    "library_count": library_count,
+                    "holding_count": int(data.get("holding_count", library_count) or 0),
+                    "copy_count": int(data.get("copy_count", library_count) or 0),
+                    "copy_count_is_exact": bool(data.get("copy_count_is_exact", False)),
+                    "trove_work_id": data.get("trove_work_id", ""),
+                }
+            matched += 1
+
+    print(f"  Trove ISBNs matched to works: {matched:,}")
+    print(f"  Unique works with Trove data: {len(work_trove):,}")
+    return work_trove
+
+
 def load_nyt(conn: sqlite3.Connection, nyt: dict) -> dict[str, dict]:
     """Map NYT bestseller ISBN-keyed data to work_keys via isbn_aliases."""
     work_nyt: dict[str, dict] = {}
@@ -245,6 +289,7 @@ def build_work_level_data(
     gr: dict | None = None,
     ottawa_isbn: dict | None = None,
     nyt: dict | None = None,
+    trove_isbn: dict | None = None,
 ) -> WorkLevelData:
     """Map third-party source dictionaries into work-keyed intermediate data."""
 
@@ -296,12 +341,19 @@ def build_work_level_data(
         work_nyt = {}
         print("  NYT bestsellers: skipped (no data)")
 
+    if trove_isbn:
+        work_trove = load_trove(conn, trove_isbn)
+    else:
+        work_trove = {}
+        print("  Trove Australia: skipped (no data)")
+
     all_works = (
         set(work_spl.keys())
         | set(work_ol.keys())
         | set(work_gr.keys())
         | set(work_ottawa.keys())
         | set(work_nyt.keys())
+        | set(work_trove.keys())
     )
     return WorkLevelData(
         work_spl=dict(work_spl),
@@ -309,6 +361,7 @@ def build_work_level_data(
         work_gr=work_gr,
         work_ottawa=work_ottawa,
         work_nyt=work_nyt,
+        work_trove=work_trove,
         all_works=all_works,
     )
 
@@ -320,6 +373,7 @@ def get_or_build_work_level_data(
     gr: dict | None,
     ottawa_isbn: dict | None,
     nyt: dict | None,
+    trove_isbn: dict | None,
     work_data_cache: dict | None,
 ) -> WorkLevelData:
     """Reuse cached work-level data or populate the cache on first use."""
@@ -331,18 +385,20 @@ def get_or_build_work_level_data(
             work_gr=work_data_cache["work_gr"],
             work_ottawa=work_data_cache["work_ottawa"],
             work_nyt=work_data_cache["work_nyt"],
+            work_trove=work_data_cache.get("work_trove", {}),
             all_works=work_data_cache["all_works"],
         )
         print(f"  Using cached work-level data ({len(data.all_works):,} works)")
         return data
 
-    data = build_work_level_data(conn, spl, ol, gr, ottawa_isbn, nyt)
+    data = build_work_level_data(conn, spl, ol, gr, ottawa_isbn, nyt, trove_isbn)
     if work_data_cache is not None:
         work_data_cache["work_spl"] = data.work_spl
         work_data_cache["work_ol"] = data.work_ol
         work_data_cache["work_gr"] = data.work_gr
         work_data_cache["work_ottawa"] = data.work_ottawa
         work_data_cache["work_nyt"] = data.work_nyt
+        work_data_cache["work_trove"] = data.work_trove
         work_data_cache["all_works"] = data.all_works
         print("  Cached work-level data for reuse")
     return data
@@ -367,11 +423,15 @@ def build_percentile_models(data: WorkLevelData) -> PercentileModels:
     lib_log_vals = [math.log10(1 + d["holds_count"]) for d in data.work_ottawa.values()]
     print(f"  Ottawa percentile base: {len(lib_log_vals):,} values")
 
+    trove_log_vals = [math.log10(1 + d["library_count"]) for d in data.work_trove.values()]
+    print(f"  Trove percentile base: {len(trove_log_vals):,} values")
+
     return PercentileModels(
         spl=make_percentile_fn(spl_log_vals),
         goodreads=make_percentile_fn(gr_log_vals),
         open_library=make_percentile_fn(ol_log_vals),
         library=make_percentile_fn(lib_log_vals),
+        trove=make_percentile_fn(trove_log_vals),
     )
 
 
@@ -423,6 +483,21 @@ def score_work_popularity(
     else:
         library_appearances = 0
 
+    trove_data = data.work_trove.get(work)
+    if trove_data:
+        trove_norm = percentiles.trove(math.log10(1 + trove_data["library_count"]))
+        trove_library_count = trove_data["library_count"]
+        trove_holding_count = trove_data.get("holding_count", trove_library_count)
+        trove_copy_count = trove_data.get("copy_count", trove_holding_count)
+        trove_copy_count_is_exact = int(bool(trove_data.get("copy_count_is_exact", False)))
+        signals.append((params.weight_trove, trove_norm))
+        total_weight += params.weight_trove
+    else:
+        trove_library_count = 0
+        trove_holding_count = 0
+        trove_copy_count = 0
+        trove_copy_count_is_exact = 0
+
     nyt_data = data.work_nyt.get(work)
     if nyt_data:
         nyt_weeks = nyt_data["weeks_on_list"]
@@ -446,6 +521,7 @@ def score_work_popularity(
             + params.weight_goodreads
             + params.weight_library
             + params.weight_nyt
+            + params.weight_trove
         ),
         1.0,
     )
@@ -466,6 +542,10 @@ def score_work_popularity(
         nyt_weeks_on_list=nyt_weeks,
         nyt_peak_rank=nyt_rank,
         library_appearances=library_appearances,
+        trove_library_count=trove_library_count,
+        trove_holding_count=trove_holding_count,
+        trove_copy_count=trove_copy_count,
+        trove_copy_count_is_exact=trove_copy_count_is_exact,
         composite_score=composite,
     )
 
@@ -475,7 +555,7 @@ def persist_work_popularity_rows(
     rows: list[WorkPopularityRow],
 ) -> None:
     conn.executemany(
-        "INSERT OR REPLACE INTO popularity_data VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT OR REPLACE INTO popularity_data VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         [row.as_db_tuple() for row in rows],
     )
 
@@ -485,18 +565,20 @@ def populate_work_level(conn: sqlite3.Connection, spl: dict, ol: dict,
                        gr: dict | None = None, w_gr: float = 0.2,
                        ottawa_isbn: dict | None = None, w_library: float = 0.05,
                        nyt: dict | None = None, w_nyt: float = 0.1,
+                       trove_isbn: dict | None = None, w_trove: float = 0.05,
                        work_data_cache: dict | None = None):
-    """Aggregate SPL + OL + Goodreads + Ottawa + NYT data at work level.
+    """Aggregate SPL + OL + Goodreads + Ottawa + NYT + Trove data at work level.
 
     If work_data_cache is provided and populated, skip the expensive ISBN→work
     mapping and reuse cached work-level dicts. The cache is a dict that this
     function populates on first call; pass the same dict on subsequent calls.
     """
     print(f"\nPopulating work-level popularity_data "
-          f"(w_spl={w_spl}, w_ol={w_ol}, w_gr={w_gr}, w_lib={w_library}, w_nyt={w_nyt}, exp={exponent})...")
+          f"(w_spl={w_spl}, w_ol={w_ol}, w_gr={w_gr}, w_lib={w_library}, "
+          f"w_nyt={w_nyt}, w_trove={w_trove}, exp={exponent})...")
 
     data = get_or_build_work_level_data(
-        conn, spl, ol, gr, ottawa_isbn, nyt, work_data_cache,
+        conn, spl, ol, gr, ottawa_isbn, nyt, trove_isbn, work_data_cache,
     )
     print(f"  Total unique works: {len(data.all_works):,}")
 
@@ -506,6 +588,7 @@ def populate_work_level(conn: sqlite3.Connection, spl: dict, ol: dict,
         weight_goodreads=w_gr,
         weight_nyt=w_nyt,
         weight_library=w_library,
+        weight_trove=w_trove,
         weight_frequency=0.0,
         exponent=exponent,
     )
@@ -526,9 +609,13 @@ def populate_work_level(conn: sqlite3.Connection, spl: dict, ol: dict,
     with_spl = conn.execute("SELECT COUNT(*) FROM popularity_data WHERE spl_checkouts > 0").fetchone()[0]
     with_gr = conn.execute("SELECT COUNT(*) FROM popularity_data WHERE gr_ratings_count > 0").fetchone()[0]
     with_lib = conn.execute("SELECT COUNT(*) FROM popularity_data WHERE library_appearances > 0").fetchone()[0]
+    with_trove = conn.execute("SELECT COUNT(*) FROM popularity_data WHERE trove_library_count > 0").fetchone()[0]
     print(f"\n  popularity_data: {total:,} works")
     with_nyt = conn.execute("SELECT COUNT(*) FROM popularity_data WHERE nyt_weeks_on_list > 0").fetchone()[0]
-    print(f"    with SPL: {with_spl:,} | with Goodreads: {with_gr:,} | with Ottawa: {with_lib:,} | with NYT: {with_nyt:,}")
+    print(
+        f"    with SPL: {with_spl:,} | with Goodreads: {with_gr:,} | "
+        f"with Ottawa: {with_lib:,} | with NYT: {with_nyt:,} | with Trove: {with_trove:,}"
+    )
 
     # Distribution
     scores = conn.execute(
@@ -536,7 +623,7 @@ def populate_work_level(conn: sqlite3.Connection, spl: dict, ol: dict,
     ).fetchall()
     vals = [r[0] for r in scores]
     n = len(vals)
-    print(f"  Composite score distribution:")
+    print("  Composite score distribution:")
     print(f"    min={vals[0]:.3f}, median={vals[n//2]:.3f}, mean={sum(vals)/n:.3f}, "
            f"p90={vals[int(n*0.9)]:.3f}, max={vals[-1]:.3f}")
 
@@ -746,11 +833,11 @@ def calibrate_thresholds(conn: sqlite3.Connection):
 
     print(f"\n=== Threshold Calibration (blend={blend}) ===")
     print(f"  Distribution: n={n}, min={scores[0]:.3f}, median={scores[min(int(n * 50 / 100), n - 1)]:.3f}, max={scores[-1]:.3f}")
-    print(f"\n  Recommended thresholds:")
+    print("\n  Recommended thresholds:")
     print(f"    accessibility_threshold_pop:         {calibration.pop_threshold:.3f}  (p92, {calibration.pop_count} fillers)")
     print(f"    accessibility_threshold_mainstream:   {calibration.mainstream_threshold:.3f}  (p64, {calibration.mainstream_count} fillers)")
     print(f"    niche: {calibration.niche_count} fillers")
-    print(f"\n  Recommended tier centers:")
+    print("\n  Recommended tier centers:")
     print(f"    tier_center_pop:         {calibration.pop_center:.3f}")
     print(f"    tier_center_mainstream:  {calibration.mainstream_center:.3f}")
     print(f"    tier_center_niche:       {calibration.niche_center:.3f}")
@@ -776,7 +863,7 @@ def calibrate_thresholds(conn: sqlite3.Connection):
 
     # Before/after comparison
     old_cfg = dict(ALL_TUNABLE_PARAMS)
-    print(f"\n  Before -> After:")
+    print("\n  Before -> After:")
     for key, new_val in params.items():
         old_val = old_cfg.get(key, "N/A")
         print(f"    {key}: {old_val} -> {new_val}")
@@ -792,6 +879,7 @@ def main():
     parser.add_argument("--gr", type=float, default=None, help="Override pop_weight_gr")
     parser.add_argument("--library", type=float, default=None, help="Override pop_weight_library")
     parser.add_argument("--nyt", type=float, default=None, help="Override pop_weight_nyt")
+    parser.add_argument("--trove", type=float, default=None, help="Override pop_weight_trove")
     parser.add_argument("--exponent", type=float, default=None, help="Override pop_exponent")
     parser.add_argument("--skip-calibrate", action="store_true", help="Skip threshold calibration")
     args = parser.parse_args()
@@ -831,6 +919,15 @@ def main():
         nyt = {}
         print("  NYT bestsellers: not found (skipping)")
 
+    # Trove Australia holdings (API-keyed optional source)
+    if TROVE_PATH.exists():
+        with open(TROVE_PATH) as f:
+            trove = json.load(f)
+        print(f"  Trove Australia: {len(trove):,} ISBNs")
+    else:
+        trove = {}
+        print("  Trove Australia: not found (skipping)")
+
     conn = sqlite3.connect(args.db)
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("PRAGMA synchronous=OFF")
@@ -845,15 +942,20 @@ def main():
     w_gr = args.gr if args.gr is not None else cfg["pop_weight_gr"]
     w_library = args.library if args.library is not None else cfg["pop_weight_library"]
     w_nyt = args.nyt if args.nyt is not None else cfg.get("pop_weight_nyt", 0.1)
+    w_trove = args.trove if args.trove is not None else cfg.get("pop_weight_trove", 0.05)
     exponent = args.exponent if args.exponent is not None else cfg["pop_exponent"]
-    print(f"  Weights: SPL={w_spl}, OL={w_ol}, GR={w_gr}, LIB={w_library}, NYT={w_nyt}, exponent={exponent}")
+    print(
+        f"  Weights: SPL={w_spl}, OL={w_ol}, GR={w_gr}, LIB={w_library}, "
+        f"NYT={w_nyt}, TROVE={w_trove}, exponent={exponent}"
+    )
 
     start = time.time()
     create_tables(conn)
     populate_work_level(conn, spl, ol, w_spl=w_spl, w_ol=w_ol, exponent=exponent,
                         gr=gr, w_gr=w_gr,
                         ottawa_isbn=ottawa_isbn, w_library=w_library,
-                        nyt=nyt, w_nyt=w_nyt)
+                        nyt=nyt, w_nyt=w_nyt,
+                        trove_isbn=trove, w_trove=w_trove)
     score_fillers_level1(conn)
     score_fillers_fallback(conn)
     report(conn)

--- a/data/trove_stream.py
+++ b/data/trove_stream.py
@@ -1,0 +1,826 @@
+"""Download Trove Australia book holdings and build an ISBN popularity lookup.
+
+Output: data/trove_holdings_lookup.json
+        (ISBN -> Trove holdings/library-count popularity metadata)
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import re
+import sqlite3
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+API_BASE = "https://api.trove.nla.gov.au/v3"
+USER_AGENT = "subtitle-generator/0.5.0 (research project; Trove holdings popularity)"
+OUTPUT_PATH = Path("data/trove_holdings_lookup.json")
+CHECKPOINT_PATH = Path("data/trove_checkpoint.json")
+OL_LOOKUP_PATH = Path("data/ol_edition_lookup.json")
+DB_PATH = Path("data/db/subtitles.db")
+
+ISBN_TEXT_RE = re.compile(r"isbn|identifier|isxn", re.IGNORECASE)
+
+
+class TroveQuotaExceeded(RuntimeError):
+    """Raised when a run-local request budget has been consumed."""
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _as_list(value) -> list:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def _as_int(value, default: int = 0) -> int:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value.replace(",", ""))
+        except ValueError:
+            return default
+    return default
+
+
+def _isbn13_checksum(digits: str) -> int:
+    total = sum((1 if idx % 2 == 0 else 3) * int(ch) for idx, ch in enumerate(digits[:12]))
+    return (10 - (total % 10)) % 10
+
+
+def _is_valid_isbn13(value: str) -> bool:
+    return (
+        len(value) == 13
+        and value.isdigit()
+        and value.startswith(("978", "979"))
+        and _isbn13_checksum(value) == int(value[-1])
+    )
+
+
+def _is_valid_isbn10(value: str) -> bool:
+    if len(value) != 10 or not value[:9].isdigit() or value[-1] not in "0123456789X":
+        return False
+    total = 0
+    for idx, ch in enumerate(value):
+        digit = 10 if ch == "X" else int(ch)
+        total += (10 - idx) * digit
+    return total % 11 == 0
+
+
+def isbn10_to_isbn13(value: str) -> str | None:
+    """Convert a valid ISBN-10 to ISBN-13."""
+
+    clean = normalize_isbn(value)
+    if not clean or len(clean) != 10:
+        return None
+    prefix = "978" + clean[:9]
+    return prefix + str(_isbn13_checksum(prefix + "0"))
+
+
+def normalize_isbn(value: str | int | None) -> str | None:
+    """Return a normalized ISBN-10 or ISBN-13 without punctuation."""
+
+    if value is None:
+        return None
+    clean = re.sub(r"[^0-9Xx]", "", str(value)).upper()
+    if _is_valid_isbn13(clean) or _is_valid_isbn10(clean):
+        return clean
+    return None
+
+
+def isbn_variants(value: str | int | None) -> set[str]:
+    """Return normalized ISBN variants useful for matching existing aliases."""
+
+    normalized = normalize_isbn(value)
+    if not normalized:
+        return set()
+    variants = {normalized}
+    if len(normalized) == 10:
+        converted = isbn10_to_isbn13(normalized)
+        if converted:
+            variants.add(converted)
+    return variants
+
+
+def _scan_isbns(text: str) -> set[str]:
+    """Extract validated ISBN-10/13 values from a string."""
+
+    compact = re.sub(r"[^0-9Xx]", "", text).upper()
+    found: set[str] = set()
+    for size in (13, 10):
+        if len(compact) < size:
+            continue
+        for idx in range(0, len(compact) - size + 1):
+            found.update(isbn_variants(compact[idx : idx + size]))
+    return found
+
+
+def extract_isbns(value, in_identifier_context: bool = False) -> set[str]:
+    """Recursively collect ISBN-like values from Trove metadata."""
+
+    found: set[str] = set()
+    if isinstance(value, dict):
+        for key, child in value.items():
+            child_context = in_identifier_context or bool(ISBN_TEXT_RE.search(str(key)))
+            found.update(extract_isbns(child, child_context))
+    elif isinstance(value, list):
+        for child in value:
+            found.update(extract_isbns(child, in_identifier_context))
+    elif isinstance(value, (str, int)):
+        text = str(value)
+        if in_identifier_context or ISBN_TEXT_RE.search(text):
+            found.update(_scan_isbns(text))
+    return found
+
+
+def _first_text(value) -> str:
+    for item in _as_list(value):
+        if isinstance(item, str) and item.strip():
+            return item.strip()
+        if isinstance(item, dict):
+            for key in ("value", "name"):
+                text = item.get(key)
+                if isinstance(text, str) and text.strip():
+                    return text.strip()
+    return ""
+
+
+def _work_id(work: dict) -> str:
+    value = work.get("id") or work.get("workId") or work.get("@id")
+    if isinstance(value, str):
+        return value
+    return str(value) if value is not None else ""
+
+
+def _holding_entries(work: dict) -> list[dict]:
+    return [item for item in _as_list(work.get("holding")) if isinstance(item, dict)]
+
+
+def extract_library_codes(work: dict) -> list[str]:
+    """Return distinct library identifiers from full-work holding entries."""
+
+    codes: set[str] = set()
+    for holding in _holding_entries(work):
+        nuc = _first_text(holding.get("nuc"))
+        if nuc:
+            codes.add(nuc)
+            continue
+        name = _first_text(holding.get("name")) or _first_text(holding.get("contributor"))
+        if name:
+            codes.add(name)
+    return sorted(codes)
+
+
+def _version_holding_count(work: dict) -> int:
+    """Return the strongest version-level holdings signal without double-counting."""
+
+    counts = []
+    for version in _as_list(work.get("version")):
+        if isinstance(version, dict):
+            counts.append(_as_int(version.get("holdingsCount")))
+    return max(counts, default=0)
+
+
+def normalize_work(
+    work: dict,
+    *,
+    queried_isbn: str | None = None,
+    include_libraries: bool = False,
+    checked_at: str | None = None,
+) -> dict[str, dict]:
+    """Normalize one Trove work into ISBN-keyed lookup entries."""
+
+    isbns = extract_isbns(work)
+    if queried_isbn:
+        isbns.update(isbn_variants(queried_isbn))
+    if not isbns:
+        return {}
+
+    libraries = extract_library_codes(work)
+    holdings_count = _as_int(work.get("holdingsCount"))
+    holding_count = holdings_count or len(libraries) or len(_holding_entries(work))
+    library_count = holdings_count or len(libraries) or holding_count
+    copy_count = holding_count
+    work_id = _work_id(work)
+    checked_at = checked_at or _utc_now()
+
+    entry = {
+        "source": "trove",
+        "trove_work_id": work_id,
+        "title": _first_text(work.get("title")),
+        "author": _first_text(work.get("contributor")),
+        "issued": _first_text(work.get("issued")),
+        "trove_url": _first_text(work.get("troveUrl") or work.get("url")),
+        "library_count": library_count,
+        "holding_count": holding_count,
+        "copy_count": copy_count,
+        "copy_count_is_exact": False,
+        "copy_count_basis": "holdings_count_proxy",
+        "version_count": _as_int(work.get("versionCount")),
+        "version_holding_count": _version_holding_count(work),
+        "last_checked": checked_at,
+    }
+    if include_libraries:
+        entry["libraries"] = libraries
+
+    return {isbn: dict(entry) for isbn in sorted(isbns)}
+
+
+def _records_from_result(payload: dict) -> list[dict]:
+    works: list[dict] = []
+    for category in _as_list(payload.get("category")):
+        if not isinstance(category, dict):
+            continue
+        records = category.get("records")
+        if isinstance(records, dict):
+            for work in _as_list(records.get("work")):
+                if isinstance(work, dict):
+                    works.append(work)
+    return works
+
+
+def _next_start(payload: dict) -> str | None:
+    for category in _as_list(payload.get("category")):
+        if isinstance(category, dict) and category.get("nextStart"):
+            return str(category["nextStart"])
+    return None
+
+
+class RateLimiter:
+    """Fixed-window limiter compatible with Trove's calls-per-minute quota."""
+
+    def __init__(self, rate_per_minute: int, state: dict | None = None):
+        self.rate_per_minute = rate_per_minute
+        state = state or {}
+        self.window_started_at = float(state.get("window_started_at_epoch") or 0.0)
+        self.requests_in_window = int(state.get("requests_in_current_window") or 0)
+        self._lock = threading.Lock()
+
+    def wait(self) -> None:
+        with self._lock:
+            now = time.time()
+            if now - self.window_started_at >= 60:
+                self.window_started_at = now
+                self.requests_in_window = 0
+            if self.requests_in_window >= self.rate_per_minute:
+                sleep_for = max(0.0, 60 - (now - self.window_started_at))
+                if sleep_for > 0:
+                    time.sleep(sleep_for)
+                self.window_started_at = time.time()
+                self.requests_in_window = 0
+            self.requests_in_window += 1
+
+    def checkpoint_state(self) -> dict:
+        with self._lock:
+            return {
+                "window_started_at_epoch": self.window_started_at,
+                "requests_in_current_window": self.requests_in_window,
+            }
+
+
+class TroveClient:
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        rate_per_minute: int,
+        quota_per_minute: int,
+        max_requests: int | None,
+        checkpoint: dict,
+    ):
+        if rate_per_minute > quota_per_minute:
+            raise ValueError(
+                f"rate_per_minute ({rate_per_minute}) cannot exceed quota_per_minute ({quota_per_minute})"
+            )
+        self.api_key = api_key
+        self.max_requests = max_requests
+        self.checkpoint = checkpoint
+        self.requests_made = int(checkpoint.get("requests_made") or 0)
+        self.limiter = RateLimiter(rate_per_minute, checkpoint)
+        self._request_lock = threading.Lock()
+
+    def _persist_request_state(self) -> None:
+        self.checkpoint["requests_made"] = self.requests_made
+        self.checkpoint.update(self.limiter.checkpoint_state())
+
+    def get_json(self, path: str, params: dict[str, str | int | bool], *, retries: int = 6) -> dict:
+        request_params = dict(params)
+        request_params["key"] = self.api_key
+        request_params.setdefault("encoding", "json")
+        url = f"{API_BASE}/{path.lstrip('/')}?{urlencode(request_params)}"
+        redacted_url = url.replace(self.api_key, "<TROVE_API_KEY>")
+
+        for attempt in range(retries + 1):
+            self.limiter.wait()
+            with self._request_lock:
+                if self.max_requests is not None and self.requests_made >= self.max_requests:
+                    raise TroveQuotaExceeded(f"Reached --max-requests={self.max_requests}")
+                self.requests_made += 1
+                self._persist_request_state()
+            req = Request(
+                url,
+                headers={
+                    "Accept": "application/json",
+                    "User-Agent": USER_AGENT,
+                },
+            )
+            try:
+                with urlopen(req, timeout=90) as response:
+                    return json.loads(response.read().decode("utf-8"))
+            except HTTPError as exc:
+                if exc.code == 429 and attempt < retries:
+                    time.sleep(60)
+                    continue
+                if exc.code in {500, 502, 503, 504} and attempt < retries:
+                    time.sleep(min(60, 5 * (attempt + 1)))
+                    continue
+                raise RuntimeError(f"Trove request failed ({exc.code}) for {redacted_url}") from exc
+            except (URLError, TimeoutError) as exc:
+                if attempt < retries:
+                    time.sleep(min(60, 2 ** attempt))
+                    continue
+                raise RuntimeError(f"Trove request failed for {redacted_url}") from exc
+
+        raise RuntimeError(f"Trove request retries exhausted for {redacted_url}")
+
+    def search(self, query: str, *, n: int = 5) -> list[dict]:
+        payload = self.get_json(
+            "result",
+            {
+                "category": "book",
+                "q": query,
+                "n": n,
+            },
+        )
+        return _records_from_result(payload)
+
+    def bulk_page(self, *, cursor: str = "*", n: int = 100, full: bool = False) -> tuple[list[dict], str | None]:
+        params: dict[str, str | int | bool] = {
+            "category": "book",
+            "bulkHarvest": "true",
+            "n": n,
+            "s": cursor,
+        }
+        if full:
+            params["reclevel"] = "full"
+            params["include"] = "workversions"
+        payload = self.get_json("result", params)
+        return _records_from_result(payload), _next_start(payload)
+
+    def work(self, work_id: str) -> dict:
+        return self.get_json(
+            f"work/{work_id}",
+            {
+                "reclevel": "full",
+                "include": "holdings,workversions",
+            },
+        )
+
+
+def load_json(path: Path, default):
+    if not path.exists():
+        return default
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, sort_keys=True)
+        f.write("\n")
+    tmp.replace(path)
+
+
+def _load_isbns_from_json_lookup(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    isbns: set[str] = set()
+    if isinstance(data, dict):
+        for key, value in data.items():
+            isbns.update(isbn_variants(key))
+            isbns.update(extract_isbns(value))
+    return isbns
+
+
+def _load_isbns_from_text(path: Path) -> set[str]:
+    isbns: set[str] = set()
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        isbns.update(isbn_variants(line.strip()))
+    return isbns
+
+
+def _load_isbns_from_db(path: Path, target_mode: str = "all") -> set[str]:
+    if not path.exists():
+        return set()
+    conn = sqlite3.connect(f"{path.resolve().as_uri()}?mode=ro", uri=True)
+    try:
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+        isbns: set[str] = set()
+        if target_mode == "slot-sources":
+            required = {"slot_filler_sources", "slot_fillers", "subtitles"}
+            if not required <= tables:
+                return set()
+            for (isbn,) in conn.execute("""
+                SELECT DISTINCT s.isbn
+                FROM slot_filler_sources sfs
+                JOIN slot_fillers sf ON sf.id = sfs.slot_filler_id
+                JOIN subtitles s ON s.id = sfs.subtitle_id
+                WHERE sf.mode = 'strict'
+                  AND s.isbn IS NOT NULL
+                  AND s.isbn != ''
+            """):
+                isbns.update(isbn_variants(isbn))
+            return isbns
+
+        if "isbn_aliases" in tables:
+            for (isbn,) in conn.execute("SELECT isbn FROM isbn_aliases"):
+                isbns.update(isbn_variants(isbn))
+        if "subtitles" in tables:
+            for (isbn,) in conn.execute("SELECT isbn FROM subtitles"):
+                isbns.update(isbn_variants(isbn))
+        return isbns
+    finally:
+        conn.close()
+
+
+def load_target_isbns(
+    paths: list[Path],
+    db_path: Path | None,
+    include_ol: bool = True,
+    db_target_mode: str = "all",
+) -> set[str]:
+    isbns: set[str] = set()
+    for path in paths:
+        if path.suffix.lower() == ".json":
+            isbns.update(_load_isbns_from_json_lookup(path))
+        else:
+            isbns.update(_load_isbns_from_text(path))
+    if include_ol:
+        isbns.update(_load_isbns_from_json_lookup(OL_LOOKUP_PATH))
+    if db_path:
+        isbns.update(_load_isbns_from_db(db_path, db_target_mode))
+    return isbns
+
+
+def _is_fresh(entry: dict, refresh_days: int) -> bool:
+    if refresh_days <= 0:
+        return False
+    raw = entry.get("last_checked")
+    if not isinstance(raw, str) or not raw:
+        return False
+    try:
+        checked = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return (datetime.now(timezone.utc) - checked).days < refresh_days
+
+
+def _best_work(works: list[dict]) -> dict | None:
+    if not works:
+        return None
+    return max(works, key=lambda work: _as_int(work.get("holdingsCount")))
+
+
+def _merge_entries(lookup: dict[str, dict], entries: dict[str, dict]) -> int:
+    changed = 0
+    for isbn, entry in entries.items():
+        existing = lookup.get(isbn)
+        if not existing or entry.get("library_count", 0) >= existing.get("library_count", 0):
+            lookup[isbn] = entry
+            changed += 1
+    return changed
+
+
+def fetch_isbn_entry(
+    client: TroveClient,
+    isbn: str,
+    *,
+    fetch_details: bool,
+    include_libraries: bool,
+) -> tuple[str, dict[str, dict], str | None]:
+    """Fetch one ISBN and return normalized lookup entries or a failure string."""
+
+    try:
+        works = client.search(f"isbn:{isbn}", n=5)
+        if not works:
+            works = client.search(f"identifier:{isbn}", n=5)
+        work = _best_work(works)
+        if not work:
+            return isbn, {}, None
+        if fetch_details or include_libraries:
+            work_id = _work_id(work)
+            if work_id:
+                work = client.work(work_id)
+        return isbn, normalize_work(work, queried_isbn=isbn, include_libraries=include_libraries), None
+    except TroveQuotaExceeded:
+        raise
+    except RuntimeError as exc:
+        return isbn, {}, str(exc)
+
+
+def build_lookup_from_csv(
+    csv_path: Path,
+    *,
+    target_isbns: set[str] | None = None,
+    include_libraries: bool = False,
+) -> dict[str, dict]:
+    """Build lookup entries from a manually exported Trove bulk-download CSV."""
+
+    lookup: dict[str, dict] = {}
+    text = csv_path.read_text(encoding="utf-8-sig", errors="replace")
+    reader = csv.DictReader(text.splitlines())
+    if not reader.fieldnames:
+        return lookup
+
+    isbn_cols = [name for name in reader.fieldnames if ISBN_TEXT_RE.search(name)]
+    id_cols = [name for name in reader.fieldnames if re.search(r"\b(work|trove).*id\b|\bid\b", name, re.IGNORECASE)]
+    count_cols = [
+        name
+        for name in reader.fieldnames
+        if re.search(r"holdings?count|libraries|library_count", name, re.IGNORECASE)
+    ]
+    title_cols = [name for name in reader.fieldnames if re.search(r"title", name, re.IGNORECASE)]
+    author_cols = [name for name in reader.fieldnames if re.search(r"author|contributor|creator", name, re.IGNORECASE)]
+
+    checked_at = _utc_now()
+    for row in reader:
+        row_isbns: set[str] = set()
+        for col in isbn_cols:
+            row_isbns.update(extract_isbns({col: row.get(col)}))
+        if target_isbns is not None:
+            row_isbns &= target_isbns
+        if not row_isbns:
+            continue
+        library_count = max([_as_int(row.get(col)) for col in count_cols], default=0)
+        entry = {
+            "source": "trove",
+            "trove_work_id": _first_text([row.get(col, "") for col in id_cols]),
+            "title": _first_text([row.get(col, "") for col in title_cols]),
+            "author": _first_text([row.get(col, "") for col in author_cols]),
+            "library_count": library_count,
+            "holding_count": library_count,
+            "copy_count": library_count,
+            "copy_count_is_exact": False,
+            "copy_count_basis": "holdings_count_proxy",
+            "last_checked": checked_at,
+        }
+        if include_libraries:
+            entry["libraries"] = []
+        _merge_entries(lookup, {isbn: dict(entry) for isbn in row_isbns})
+    return lookup
+
+
+def download_by_isbn(
+    client: TroveClient,
+    target_isbns: set[str],
+    lookup: dict[str, dict],
+    checkpoint: dict,
+    *,
+    limit: int | None,
+    refresh_days: int,
+    fetch_details: bool,
+    include_libraries: bool,
+    save_every: int,
+    workers: int,
+    output_path: Path,
+    checkpoint_path: Path,
+) -> int:
+    processed = set(checkpoint.get("processed_isbns") or [])
+    failed = dict(checkpoint.get("failed_isbns") or {})
+    added = 0
+    candidates: list[str] = []
+    for isbn in sorted(target_isbns):
+        if isbn in processed:
+            continue
+        if isbn in lookup and _is_fresh(lookup[isbn], refresh_days):
+            processed.add(isbn)
+            continue
+        candidates.append(isbn)
+        if limit is not None and len(candidates) >= limit:
+            break
+
+    def sync_checkpoint() -> None:
+        checkpoint["processed_isbns"] = sorted(processed)
+        checkpoint["failed_isbns"] = failed
+
+    def persist(checked: int) -> None:
+        sync_checkpoint()
+        save_json(output_path, lookup)
+        save_json(checkpoint_path, checkpoint)
+        print(f"  Checked {checked:,} ISBNs this run; lookup has {len(lookup):,} entries")
+
+    checked = 0
+    try:
+        if workers <= 1:
+            for isbn in candidates:
+                isbn, entries, failure = fetch_isbn_entry(
+                    client,
+                    isbn,
+                    fetch_details=fetch_details,
+                    include_libraries=include_libraries,
+                )
+                if failure:
+                    failed[isbn] = failure
+                    print(f"  Failed {isbn}: {failure}", file=sys.stderr)
+                else:
+                    added += _merge_entries(lookup, entries)
+                    processed.add(isbn)
+                checked += 1
+                if checked % save_every == 0:
+                    persist(checked)
+        else:
+            executor = ThreadPoolExecutor(max_workers=workers)
+            futures = [
+                executor.submit(
+                    fetch_isbn_entry,
+                    client,
+                    isbn,
+                    fetch_details=fetch_details,
+                    include_libraries=include_libraries,
+                )
+                for isbn in candidates
+            ]
+            try:
+                for future in as_completed(futures):
+                    isbn, entries, failure = future.result()
+                    if failure:
+                        failed[isbn] = failure
+                        print(f"  Failed {isbn}: {failure}", file=sys.stderr)
+                    else:
+                        added += _merge_entries(lookup, entries)
+                        processed.add(isbn)
+                    checked += 1
+                    if checked % save_every == 0:
+                        persist(checked)
+            except TroveQuotaExceeded:
+                for future in futures:
+                    future.cancel()
+                raise
+            finally:
+                executor.shutdown(wait=False, cancel_futures=True)
+    finally:
+        sync_checkpoint()
+        save_json(output_path, lookup)
+        save_json(checkpoint_path, checkpoint)
+    return added
+
+
+def download_bulk_pages(
+    client: TroveClient,
+    lookup: dict[str, dict],
+    checkpoint: dict,
+    *,
+    target_isbns: set[str] | None,
+    pages: int,
+    page_size: int,
+    full: bool,
+    include_libraries: bool,
+    output_path: Path,
+    checkpoint_path: Path,
+) -> int:
+    cursor = str(checkpoint.get("bulk_cursor") or "*")
+    added = 0
+    for page in range(pages):
+        works, next_start = client.bulk_page(cursor=cursor, n=page_size, full=full)
+        if full and not next_start:
+            _, next_start = client.bulk_page(cursor=cursor, n=page_size, full=False)
+        for work in works:
+            entries = normalize_work(work, include_libraries=include_libraries)
+            if target_isbns is not None:
+                entries = {isbn: entry for isbn, entry in entries.items() if isbn in target_isbns}
+            added += _merge_entries(lookup, entries)
+        checkpoint["bulk_cursor"] = next_start
+        save_json(output_path, lookup)
+        save_json(checkpoint_path, checkpoint)
+        print(f"  Bulk page {page + 1:,}/{pages:,}: {len(works):,} works, lookup has {len(lookup):,} entries")
+        if not next_start:
+            break
+        cursor = next_start
+    return added
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Download Trove holdings into an ISBN lookup")
+    parser.add_argument("--api-key", default=os.environ.get("TROVE_API_KEY"), help="Trove API key or TROVE_API_KEY")
+    parser.add_argument("--output", type=Path, default=OUTPUT_PATH)
+    parser.add_argument("--checkpoint", type=Path, default=CHECKPOINT_PATH)
+    parser.add_argument("--target-isbns", type=Path, action="append", default=[], help="Text or JSON file containing target ISBNs")
+    parser.add_argument("--db", type=Path, default=DB_PATH, help="Optional subtitles DB used to load target ISBNs")
+    parser.add_argument(
+        "--db-target-mode",
+        choices=["all", "slot-sources"],
+        default="all",
+        help="Which ISBNs to load from --db",
+    )
+    parser.add_argument("--no-ol-targets", action="store_true", help="Do not load target ISBNs from data/ol_edition_lookup.json")
+    parser.add_argument("--limit", type=int, default=None, help="Maximum ISBNs to check this run")
+    parser.add_argument("--max-requests", type=int, default=None, help="Maximum Trove API requests this run")
+    parser.add_argument("--rate-per-minute", type=int, default=180, help="Request rate, capped by --quota-per-minute")
+    parser.add_argument("--quota-per-minute", type=int, default=200, help="Approved Trove API quota")
+    parser.add_argument("--refresh-days", type=int, default=30, help="Skip lookup entries checked more recently than this")
+    parser.add_argument("--include-libraries", action="store_true", help="Persist distinct library NUC/name list")
+    parser.add_argument("--fetch-details", action="store_true", help="Fetch full work records for matched ISBNs")
+    parser.add_argument("--workers", type=int, default=1, help="Concurrent targeted ISBN workers")
+    parser.add_argument("--bulk-pages", type=int, default=0, help="Also harvest this many bulk result pages")
+    parser.add_argument("--bulk-full", action="store_true", help="Use reclevel=full&include=workversions for bulk pages")
+    parser.add_argument("--bulk-page-size", type=int, default=100)
+    parser.add_argument("--csv", type=Path, action="append", default=[], help="Import manually exported Trove bulk CSV before API calls")
+    parser.add_argument("--save-every", type=int, default=25)
+    parser.add_argument("--no-resume", action="store_true", help="Ignore existing checkpoint")
+    args = parser.parse_args()
+
+    if not args.api_key and (args.limit != 0 or args.bulk_pages):
+        raise SystemExit("Trove requires --api-key or TROVE_API_KEY")
+
+    target_isbns = load_target_isbns(
+        args.target_isbns,
+        args.db,
+        include_ol=not args.no_ol_targets,
+        db_target_mode=args.db_target_mode,
+    )
+    lookup = load_json(args.output, {})
+    checkpoint = {} if args.no_resume else load_json(args.checkpoint, {})
+
+    for csv_path in args.csv:
+        imported = build_lookup_from_csv(
+            csv_path,
+            target_isbns=target_isbns or None,
+            include_libraries=args.include_libraries,
+        )
+        _merge_entries(lookup, imported)
+        print(f"Imported {len(imported):,} entries from {csv_path}")
+
+    if args.api_key:
+        client = TroveClient(
+            args.api_key,
+            rate_per_minute=args.rate_per_minute,
+            quota_per_minute=args.quota_per_minute,
+            max_requests=args.max_requests,
+            checkpoint=checkpoint,
+        )
+        try:
+            if args.bulk_pages:
+                download_bulk_pages(
+                    client,
+                    lookup,
+                    checkpoint,
+                    target_isbns=target_isbns or None,
+                    pages=args.bulk_pages,
+                    page_size=args.bulk_page_size,
+                    full=args.bulk_full,
+                    include_libraries=args.include_libraries,
+                    output_path=args.output,
+                    checkpoint_path=args.checkpoint,
+                )
+            if target_isbns and args.limit != 0:
+                download_by_isbn(
+                    client,
+                    target_isbns,
+                    lookup,
+                    checkpoint,
+                    limit=args.limit,
+                    refresh_days=args.refresh_days,
+                    fetch_details=args.fetch_details,
+                    include_libraries=args.include_libraries,
+                    save_every=args.save_every,
+                    workers=max(args.workers, 1),
+                    output_path=args.output,
+                    checkpoint_path=args.checkpoint,
+                )
+        except TroveQuotaExceeded as exc:
+            save_json(args.output, lookup)
+            save_json(args.checkpoint, checkpoint)
+            print(f"Stopped: {exc}", file=sys.stderr)
+
+    save_json(args.output, lookup)
+    save_json(args.checkpoint, checkpoint)
+    print(f"Done. Trove lookup: {len(lookup):,} ISBN entries -> {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/pipeline-end-to-end.md
+++ b/docs/pipeline-end-to-end.md
@@ -80,6 +80,7 @@ flowchart TD
     gr[Goodreads ratings] --> pop
     ottawa[Ottawa/library holds] --> pop
     nyt[NYT bestsellers] --> pop
+    trove[Trove Australia holdings] --> pop
     aliases --> pop
     pop --> popularity[(popularity_data)]
     pop --> fillers
@@ -126,6 +127,7 @@ The generator is grounded in real book/catalog data:
 | Goodreads/UCSD Book Graph | Demand/engagement signal | ISBN-keyed ratings counts mapped to works. |
 | Ottawa/Canadian library data | Library holds/appearances signal | ISBN-keyed library demand mapped to works. |
 | NYT bestseller data | Bestseller signal | ISBN-keyed bestseller appearances mapped to works. |
+| Trove Australia data | Library breadth/holdings signal | ISBN-keyed Trove `holdingsCount` mapped to works; exact physical copy counts are not assumed. |
 
 Human ratings are not population inputs. They are feedback used by tuning and
 analysis.
@@ -250,6 +252,7 @@ intermediate structures:
 - `work_gr`
 - `work_ottawa`
 - `work_nyt`
+- `work_trove`
 - `all_works`
 
 Each source is normalized onto a percentile scale using `log10(1 + raw_value)`.
@@ -274,7 +277,9 @@ $$
 where confidence is based on the amount of demand-source weight actually
 observed. Works with no demand sources are capped so Open Library alone cannot
 make them look like high-demand pop titles. NYT appearances get a high floor
-because even partial bestseller-list presence is meaningful.
+because even partial bestseller-list presence is meaningful. Trove uses
+Australian `holdingsCount` as a library-breadth signal and stores copy counts as
+a documented proxy unless Trove exposes exact copy fields.
 
 The persisted result is one row per work in `popularity_data`.
 
@@ -720,7 +725,7 @@ they are not applied silently.
 
 | Parameter family | Affects | Needs repopulate? | Needs recalibration? |
 |---|---|---:|---:|
-| `pop_weight_spl`, `pop_weight_ol`, `pop_weight_gr`, `pop_weight_nyt`, `pop_weight_library` | Work-level `composite_score` and filler `popularity_score` | Yes | Yes |
+| `pop_weight_spl`, `pop_weight_ol`, `pop_weight_gr`, `pop_weight_nyt`, `pop_weight_library`, `pop_weight_trove` | Work-level `composite_score` and filler `popularity_score` | Yes | Yes |
 | `pop_exponent` | Source score contrast before work-level scoring | Yes | Yes |
 | `pop_classification_blend` | Tier classification and tone-bias alignment | No | Yes |
 | `pop_missing_default` | Missing-popularity filler classification | No | Yes |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "subtitle-generator"
-version = "0.4.0"
+version = "0.5.0"
 description = "Generate bizarre book subtitles by mixing real parts from Library of Congress MARC records"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/subtitle_generator/__init__.py
+++ b/src/subtitle_generator/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("subtitle-generator")
 except PackageNotFoundError:
-    __version__ = "0.4.0"
+    __version__ = "0.5.0"

--- a/src/subtitle_generator/cli.py
+++ b/src/subtitle_generator/cli.py
@@ -1064,13 +1064,14 @@ def pull_ratings_cmd(ctx, since: str | None, account: str | None):
     click.echo(f"Synced {synced} ratings ({skipped} duplicates skipped).")
 
 
-_POP_SOURCES = ["spl", "ol", "gr", "ottawa", "nyt"]
+_POP_SOURCES = ["spl", "ol", "gr", "ottawa", "nyt", "trove"]
 _POP_LOOKUP_FILES = {
     "spl": Path("data/spl_checkout_lookup.json"),
     "ol": Path("data/ol_edition_lookup.json"),
     "gr": Path("data/goodreads_lookup.json"),
     "ottawa": Path("data/canadian_library_lookup.json"),
     "nyt": Path("data/nyt_bestseller_lookup.json"),
+    "trove": Path("data/trove_holdings_lookup.json"),
 }
 
 
@@ -1094,12 +1095,47 @@ def _pop_status():
 
 
 @cli.command("download-popularity")
-@click.option("--sources", default=None, help="Comma-separated sources to download (spl,ol,gr,ottawa,nyt). Default: all except nyt without API key.")
+@click.option("--sources", default=None, help="Comma-separated sources to download (spl,ol,gr,ottawa,nyt,trove). Default: all except API-keyed sources without keys.")
 @click.option("--nyt-api-key", default=None, envvar="NYT_API_KEY", help="NYT API key (or set NYT_API_KEY env var)")
 @click.option("--nyt-max-requests", type=int, default=None, help="Stop NYT after N requests")
+@click.option("--trove-api-key", default=None, envvar="TROVE_API_KEY", help="Trove API key (or set TROVE_API_KEY env var)")
+@click.option("--trove-limit", type=int, default=None, help="Stop Trove after N target ISBNs")
+@click.option("--trove-max-requests", type=int, default=None, help="Stop Trove after N API requests")
+@click.option("--trove-rate-per-minute", type=int, default=180, show_default=True, help="Trove request rate below quota")
+@click.option("--trove-quota-per-minute", type=int, default=200, show_default=True, help="Approved Trove quota")
+@click.option("--trove-workers", type=int, default=1, show_default=True, help="Concurrent Trove ISBN workers")
+@click.option("--trove-bulk-pages", type=int, default=0, help="Harvest N Trove bulk pages before targeted ISBN search")
+@click.option("--trove-bulk-page-size", type=int, default=20, show_default=True, help="Trove works per bulk page")
+@click.option("--trove-bulk-full", is_flag=True, help="Use full work/version records for Trove bulk pages")
+@click.option("--trove-db", type=click.Path(path_type=Path), default=DB_PATH, show_default=True, help="SQLite DB used for Trove target ISBNs")
+@click.option(
+    "--trove-target-mode",
+    type=click.Choice(["slot-sources", "all"]),
+    default="slot-sources",
+    show_default=True,
+    help="Which ISBNs to load from --trove-db",
+)
+@click.option("--trove-include-libraries", is_flag=True, help="Persist Trove library NUC/name lists")
 @click.option("--status", is_flag=True, help="Show what's downloaded and exit")
-def download_popularity(sources, nyt_api_key, nyt_max_requests, status):
-    """Download popularity data sources (SPL, OL editions, Goodreads, Ottawa, NYT).
+def download_popularity(
+    sources,
+    nyt_api_key,
+    nyt_max_requests,
+    trove_api_key,
+    trove_limit,
+    trove_max_requests,
+    trove_rate_per_minute,
+    trove_quota_per_minute,
+    trove_workers,
+    trove_bulk_pages,
+    trove_bulk_page_size,
+    trove_bulk_full,
+    trove_db,
+    trove_target_mode,
+    trove_include_libraries,
+    status,
+):
+    """Download popularity data sources (SPL, OL editions, Goodreads, Ottawa, NYT, Trove).
 
     \b
     Sources:
@@ -1108,12 +1144,16 @@ def download_popularity(sources, nyt_api_key, nyt_max_requests, status):
       gr      Goodreads / UCSD Book Graph (~2 GB download)
       ottawa  Ottawa Public Library holds data
       nyt     NYT bestseller lists (multi-day, resumable, needs API key)
+      trove   Trove Australia book holdings (resumable, needs API key)
 
     \b
     Examples:
       subtitle-gen download-popularity                    # all (except NYT w/o key)
       subtitle-gen download-popularity --sources spl,gr   # specific sources
       subtitle-gen download-popularity --sources nyt --nyt-api-key KEY
+      subtitle-gen download-popularity --sources trove --trove-limit 100
+      subtitle-gen download-popularity --sources trove --trove-bulk-pages 1000 --trove-bulk-full
+      subtitle-gen download-popularity --sources trove --trove-db data/db/subtitles.db
       subtitle-gen download-popularity --status           # show what's downloaded
     """
     import subprocess
@@ -1129,7 +1169,10 @@ def download_popularity(sources, nyt_api_key, nyt_max_requests, status):
         if invalid:
             raise click.ClickException(f"Unknown source(s): {', '.join(invalid)}. Choose from: {', '.join(_POP_SOURCES)}")
     else:
-        selected = [s for s in _POP_SOURCES if s != "nyt" or nyt_api_key]
+        selected = [
+            s for s in _POP_SOURCES
+            if (s != "nyt" or nyt_api_key) and (s != "trove" or trove_api_key)
+        ]
 
     for src in selected:
         click.echo(f"\n{'=' * 60}")
@@ -1167,6 +1210,35 @@ def download_popularity(sources, nyt_api_key, nyt_max_requests, status):
             # Auto-export partial data to lookup JSON
             subprocess.run([sys.executable, "data/nyt_stream.py", "--export"], check=True)
 
+        elif src == "trove":
+            if not trove_api_key:
+                raise click.ClickException("Trove requires --trove-api-key or TROVE_API_KEY env var.")
+            args = [
+                sys.executable, "data/trove_stream.py",
+                "--api-key", trove_api_key,
+                "--rate-per-minute", str(trove_rate_per_minute),
+                "--quota-per-minute", str(trove_quota_per_minute),
+                "--workers", str(trove_workers),
+                "--db", str(trove_db),
+                "--db-target-mode", trove_target_mode,
+                "--no-ol-targets",
+            ]
+            if trove_bulk_pages:
+                args.extend([
+                    "--bulk-pages", str(trove_bulk_pages),
+                    "--bulk-page-size", str(trove_bulk_page_size),
+                    "--limit", "0",
+                ])
+                if trove_bulk_full:
+                    args.append("--bulk-full")
+            if trove_limit is not None:
+                args.extend(["--limit", str(trove_limit)])
+            if trove_max_requests is not None:
+                args.extend(["--max-requests", str(trove_max_requests)])
+            if trove_include_libraries:
+                args.append("--include-libraries")
+            subprocess.run(args, check=True)
+
     click.echo(f"\n{'=' * 60}")
     click.echo("Summary:")
     _pop_status()
@@ -1178,16 +1250,17 @@ def download_popularity(sources, nyt_api_key, nyt_max_requests, status):
 @click.option("--gr", "w_gr", type=float, default=None, help="Override pop_weight_gr")
 @click.option("--library", "w_library", type=float, default=None, help="Override pop_weight_library")
 @click.option("--nyt", "w_nyt", type=float, default=None, help="Override pop_weight_nyt")
+@click.option("--trove", "w_trove", type=float, default=None, help="Override pop_weight_trove")
 @click.option("--exponent", type=float, default=None, help="Override pop_exponent")
 @click.option("--skip-calibrate", is_flag=True, help="Skip threshold calibration")
 @click.option("--skip-data-model", is_flag=True, help="Skip ISBN alias / filler-source rebuild")
-def populate_popularity(w_spl, w_ol, w_gr, w_library, w_nyt, exponent, skip_calibrate, skip_data_model):
+def populate_popularity(w_spl, w_ol, w_gr, w_library, w_nyt, w_trove, exponent, skip_calibrate, skip_data_model):
     """Build ISBN mappings and compute popularity scores from all available sources.
 
     \b
     Runs the full popularity pipeline:
       1. Build ISBN aliases + filler-source mapping (unless --skip-data-model)
-      2. Load all available popularity lookups (SPL, OL, Goodreads, Ottawa, NYT)
+      2. Load all available popularity lookups (SPL, OL, Goodreads, Ottawa, NYT, Trove)
       3. Compute composite scores via weighted-average percentile normalization
       4. Score slot fillers (L1 top-3 mean + L2 corpus fallback)
       5. Auto-calibrate tier thresholds (unless --skip-calibrate)
@@ -1218,6 +1291,8 @@ def populate_popularity(w_spl, w_ol, w_gr, w_library, w_nyt, exponent, skip_cali
         args.extend(["--library", str(w_library)])
     if w_nyt is not None:
         args.extend(["--nyt", str(w_nyt)])
+    if w_trove is not None:
+        args.extend(["--trove", str(w_trove)])
     if exponent is not None:
         args.extend(["--exponent", str(exponent)])
     if skip_calibrate:

--- a/src/subtitle_generator/config.py
+++ b/src/subtitle_generator/config.py
@@ -27,6 +27,8 @@ ALL_TUNABLE_PARAMS: dict[str, float] = {
     "pop_weight_gr": 0.2,       # Weight of Goodreads ratings signal
     "pop_weight_nyt": 0.1,      # Weight of NYT bestseller signal
     "pop_weight_library": 0.05, # Weight of other library lists signal
+    "pop_weight_trove": 0.05,   # Weight of Trove Australia holdings signal
+    "pop_weight_freq": 0.0,
     "pop_exponent": 1.2,
     "pop_base_weight_blend": 0.5,
     "pop_classification_blend": 0.9,

--- a/src/subtitle_generator/eval_harness.py
+++ b/src/subtitle_generator/eval_harness.py
@@ -14,7 +14,6 @@ import sqlite3
 import warnings
 
 import click
-import litellm
 from pydantic import BaseModel
 
 from subtitle_generator.generate import generate_subtitles, generate_subtitles_by_tier
@@ -32,6 +31,26 @@ warnings.filterwarnings("ignore", message="coroutine.*was never awaited")
 # ---------------------------------------------------------------------------
 
 _RESPONSES_ONLY_MODELS = RESPONSES_ONLY_MODELS
+
+
+def _litellm():
+    """Import litellm only when an LLM call is actually requested.
+
+    The tuning package is optional in pyproject.toml, but many non-LLM tests
+    import this module through subtitle_generator.tune. Keeping the import lazy
+    lets those tests run in the default development environment while still
+    surfacing a clear error when someone invokes LLM-backed evaluation without
+    installing the optional tune dependencies.
+    """
+
+    try:
+        import litellm
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "litellm is required for LLM-backed evaluation. "
+            "Install the optional tune dependencies before running tuning."
+        ) from exc
+    return litellm
 
 # ---------------------------------------------------------------------------
 # Pydantic schemas
@@ -92,6 +111,7 @@ def structured_completion(
     """
     model_lower = model.lower()
     last_error = None
+    llm = _litellm()
 
     for attempt in range(1 + max_retries):
         try:
@@ -99,7 +119,7 @@ def structured_completion(
                 # Responses API — native structured output via text_format
                 user_content = messages[-1]["content"] if messages else ""
                 timeout = kwargs.pop("timeout", 60.0) if attempt == 0 else kwargs.get("timeout", 60.0)
-                resp = asyncio.run(litellm.aresponses(
+                resp = asyncio.run(llm.aresponses(
                     model=model,
                     input=user_content,
                     text_format=schema,
@@ -114,7 +134,7 @@ def structured_completion(
             use_native = "gpt" in model_lower or "o3" in model_lower or "o4" in model_lower
 
             if use_native:
-                resp = litellm.completion(
+                resp = llm.completion(
                     model=model,
                     messages=messages,
                     response_format=schema,
@@ -133,7 +153,7 @@ def structured_completion(
                         "parameters": schema.model_json_schema(),
                     },
                 }
-                resp = litellm.completion(
+                resp = llm.completion(
                     model=model,
                     messages=messages,
                     tools=[tool_schema],

--- a/src/subtitle_generator/parameter_state.py
+++ b/src/subtitle_generator/parameter_state.py
@@ -35,6 +35,8 @@ class PopularityParameters:
     weight_goodreads: float
     weight_nyt: float
     weight_library: float
+    weight_trove: float
+    weight_frequency: float
     exponent: float
 
 
@@ -136,6 +138,8 @@ def get_popularity_parameters(conn: sqlite3.Connection | None = None) -> Popular
         weight_goodreads=cfg["pop_weight_gr"],
         weight_nyt=cfg["pop_weight_nyt"],
         weight_library=cfg["pop_weight_library"],
+        weight_trove=cfg["pop_weight_trove"],
+        weight_frequency=cfg["pop_weight_freq"],
         exponent=cfg["pop_exponent"],
     )
 

--- a/src/subtitle_generator/schema_contracts.py
+++ b/src/subtitle_generator/schema_contracts.py
@@ -60,7 +60,9 @@ SCHEMA_CONTRACTS: tuple[TableContract, ...] = (
             "work_key", "spl_checkouts", "spl_years", "spl_earliest_pub_year",
             "ol_edition_count", "checkouts_per_year", "editions_per_decade",
             "gr_ratings_count", "gr_average_rating", "nyt_weeks_on_list",
-            "nyt_peak_rank", "library_appearances", "composite_score",
+            "nyt_peak_rank", "library_appearances", "trove_library_count",
+            "trove_holding_count", "trove_copy_count",
+            "trove_copy_count_is_exact", "composite_score",
         }),
     ),
     TableContract(

--- a/src/subtitle_generator/tune.py
+++ b/src/subtitle_generator/tune.py
@@ -14,6 +14,7 @@ import json
 import pathlib
 import re
 import sqlite3
+import sys
 
 import click
 
@@ -55,6 +56,12 @@ AUTOTUNE_PARAM_KEYS = frozenset({
 # Helpers
 # ---------------------------------------------------------------------------
 
+# Parameters that require re-running populate-popularity to take effect.
+# These change the composite scoring formula, not just generation-time behavior.
+_REPOPULATE_PARAMS = frozenset({
+    "pop_weight_spl", "pop_weight_ol", "pop_weight_gr",
+    "pop_weight_nyt", "pop_weight_library", "pop_weight_trove", "pop_exponent",
+})
 
 def _autotune_param_keys() -> set[str]:
     """Return config keys that the autoresearch loop is allowed to propose."""
@@ -90,6 +97,321 @@ def _proposal_change(
         old_value=current_params[proposal.param],
         new_value=new_value,
     ), clamped_from
+
+
+def _run_calibrate_thresholds(conn: sqlite3.Connection) -> None:
+    """Re-derive accessibility thresholds, tier centers, and tone targets from
+    the current blended-score distribution. Cheap; safe to call after any
+    repopulate or after a pop_classification_blend / pop_missing_default change.
+    """
+    import contextlib
+    import importlib
+    import io
+    sys.path.insert(0, "data")
+    import populate_popularity as pp
+    importlib.reload(pp)
+    # Suppress the verbose threshold report; tune loop only needs the new values
+    # to be live in config, not a 30-line dump every iteration.
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        pp.calibrate_thresholds(conn)
+    conn.commit()
+    invalidate_config_cache()
+    # One-line summary
+    cfg = load_tuning_config(conn)
+    click.echo(
+        f"  [calibrate] thresholds pop={cfg.get('accessibility_threshold_pop'):.3f} "
+        f"main={cfg.get('accessibility_threshold_mainstream'):.3f} "
+        f"centers pop={cfg.get('tier_center_pop'):.3f} "
+        f"main={cfg.get('tier_center_mainstream'):.3f} "
+        f"niche={cfg.get('tier_center_niche'):.3f}"
+    )
+
+
+# Cached popularity data (loaded once, reused across tuner iterations)
+_pop_data_cache: dict | None = None
+_work_data_cache: dict = {}
+_filler_works_cache: dict | None = None  # filler_id -> list of work_keys
+_filler_freq_cache: dict | None = None   # filler_id -> freq (for fallback)
+
+
+def _load_pop_data():
+    """Load all popularity JSON files (cached across calls)."""
+    global _pop_data_cache
+    if _pop_data_cache is not None:
+        return _pop_data_cache
+
+    import json
+    from pathlib import Path
+
+    click.echo("  [repopulate] loading popularity data (first time, will cache)...")
+    data = {}
+    spl_path = Path("data/spl_checkout_lookup.json")
+    ol_path = Path("data/ol_edition_lookup.json")
+    gr_path = Path("data/goodreads_lookup.json")
+    ottawa_path = Path("data/canadian_library_lookup.json")
+    nyt_path = Path("data/nyt_bestseller_lookup.json")
+    trove_path = Path("data/trove_holdings_lookup.json")
+
+    with open(spl_path) as f:
+        data["spl"] = json.load(f)
+    with open(ol_path) as f:
+        data["ol"] = json.load(f)
+
+    if gr_path.exists():
+        with open(gr_path) as f:
+            data["gr"] = json.load(f)
+    else:
+        data["gr"] = {}
+
+    if ottawa_path.exists():
+        with open(ottawa_path) as f:
+            raw = json.load(f)
+        data["ottawa_isbn"] = {k: v for k, v in raw.items() if k.replace("-", "").isdigit()}
+    else:
+        data["ottawa_isbn"] = {}
+
+    if nyt_path.exists():
+        with open(nyt_path) as f:
+            data["nyt"] = json.load(f)
+    else:
+        data["nyt"] = {}
+
+    if trove_path.exists():
+        with open(trove_path) as f:
+            data["trove"] = json.load(f)
+    else:
+        data["trove"] = {}
+
+    _pop_data_cache = data
+    click.echo(f"  [repopulate] cached: SPL={len(data['spl']):,}, OL={len(data['ol']):,}, "
+               f"GR={len(data['gr']):,}, Ottawa={len(data['ottawa_isbn']):,}, "
+               f"NYT={len(data['nyt']):,}, Trove={len(data['trove']):,}")
+    return data
+
+
+def _load_filler_works(conn: sqlite3.Connection):
+    """Build filler_id -> [work_keys] mapping (cached)."""
+    global _filler_works_cache, _filler_freq_cache
+    if _filler_works_cache is not None:
+        return _filler_works_cache, _filler_freq_cache
+
+    click.echo("  [repopulate] building filler->work mapping (first time)...")
+    from collections import defaultdict
+
+    rows = conn.execute("""
+        SELECT sf.id, ia.work_key
+        FROM slot_fillers sf
+        JOIN slot_filler_sources sfs ON sfs.slot_filler_id = sf.id
+        JOIN subtitles s ON sfs.subtitle_id = s.id
+        JOIN isbn_aliases ia ON ia.isbn = s.isbn
+        WHERE ia.work_key IS NOT NULL AND sf.mode = 'strict'
+    """).fetchall()
+
+    filler_works = defaultdict(list)
+    for fid, wk in rows:
+        filler_works[fid].append(wk)
+    # Deduplicate
+    _filler_works_cache = {fid: list(set(wks)) for fid, wks in filler_works.items()}
+
+    # Also cache freq for fallback scoring
+    freq_rows = conn.execute(
+        "SELECT id, freq FROM slot_fillers WHERE mode = 'strict'"
+    ).fetchall()
+    _filler_freq_cache = {r[0]: r[1] for r in freq_rows}
+
+    click.echo(f"  [repopulate] cached {len(_filler_works_cache):,} fillers with work mappings")
+    return _filler_works_cache, _filler_freq_cache
+
+
+def _score_in_memory(conn: sqlite3.Connection):
+    """Compute composite scores in memory and write only filler scores to DB.
+
+    Returns the work_composites dict for use by _flush_repopulate if kept.
+    """
+    import bisect
+    import math
+    import time as _time
+
+    t0 = _time.time()
+    _load_pop_data()
+    cfg = load_tuning_config(conn)
+
+    w_spl = cfg.get("pop_weight_spl", 0.7)
+    w_ol = cfg.get("pop_weight_ol", 0.3)
+    w_gr = cfg.get("pop_weight_gr", 0.2)
+    w_library = cfg.get("pop_weight_library", 0.05)
+    w_nyt = cfg.get("pop_weight_nyt", 0.1)
+    w_trove = cfg.get("pop_weight_trove", 0.05)
+
+    click.echo(f"  [repopulate] scoring in-memory (SPL={w_spl}, OL={w_ol}, "
+               f"GR={w_gr}, LIB={w_library}, NYT={w_nyt}, TROVE={w_trove})...")
+
+    # Ensure work-level data is cached
+    if "work_spl" not in _work_data_cache:
+        # Need a full run first to populate the cache
+        click.echo("  [repopulate] cold start: need full populate for work data cache")
+        _run_repopulate_full(conn)
+        return None
+
+    work_spl = _work_data_cache["work_spl"]
+    work_ol = _work_data_cache["work_ol"]
+    work_gr = _work_data_cache["work_gr"]
+    work_ottawa = _work_data_cache["work_ottawa"]
+    work_nyt = _work_data_cache["work_nyt"]
+    work_trove = _work_data_cache.get("work_trove", {})
+    all_works = _work_data_cache["all_works"]
+
+    # Build percentile arrays
+    spl_log_vals = sorted([math.log10(1 + d["checkouts"] / max(d["years"], 1))
+                           for d in work_spl.values() if d["checkouts"] > 0])
+    gr_log_vals = sorted([math.log10(1 + d["ratings_count"]) for d in work_gr.values()])
+    ol_log_vals = sorted([math.log10(1 + ec) for ec in work_ol.values()])
+    lib_log_vals = sorted([math.log10(1 + d["holds_count"]) for d in work_ottawa.values()])
+    trove_log_vals = sorted([math.log10(1 + d["library_count"]) for d in work_trove.values()])
+
+    n_spl = len(spl_log_vals) or 1
+    n_gr = len(gr_log_vals) or 1
+    n_ol = len(ol_log_vals) or 1
+    n_lib = len(lib_log_vals) or 1
+    n_trove = len(trove_log_vals) or 1
+
+    # Score all works in memory (dict, no DB)
+    work_composites: dict[str, float] = {}
+    denom = w_spl + w_gr + w_library + w_nyt + w_trove
+
+    for work in all_works:
+        signals = []
+        total_weight = 0.0
+
+        spl_data = work_spl.get(work)
+        if spl_data and spl_data["checkouts"] > 0:
+            co_per_year = spl_data["checkouts"] / max(spl_data["years"], 1)
+            spl_norm = bisect.bisect_left(spl_log_vals, math.log10(1 + co_per_year)) / n_spl
+            signals.append((w_spl, spl_norm))
+            total_weight += w_spl
+
+        gr_data = work_gr.get(work)
+        if gr_data:
+            gr_norm = bisect.bisect_left(gr_log_vals, math.log10(1 + gr_data["ratings_count"])) / n_gr
+            signals.append((w_gr, gr_norm))
+            total_weight += w_gr
+
+        can_data = work_ottawa.get(work)
+        if can_data:
+            lib_norm = bisect.bisect_left(lib_log_vals, math.log10(1 + can_data["holds_count"])) / n_lib
+            signals.append((w_library, lib_norm))
+            total_weight += w_library
+
+        trove_data = work_trove.get(work)
+        if trove_data:
+            trove_norm = bisect.bisect_left(trove_log_vals, math.log10(1 + trove_data["library_count"])) / n_trove
+            signals.append((w_trove, trove_norm))
+            total_weight += w_trove
+
+        nyt_data = work_nyt.get(work)
+        if nyt_data:
+            nyt_norm = min(1.0, 0.8 + 0.2 * math.log10(1 + nyt_data["weeks_on_list"]) / 2.0)
+            signals.append((w_nyt, nyt_norm))
+            total_weight += w_nyt
+
+        if total_weight > 0:
+            demand_score = sum(w * s for w, s in signals) / total_weight
+        else:
+            demand_score = 0.0
+
+        ol_ec = work_ol.get(work, 1)
+        ol_norm = bisect.bisect_left(ol_log_vals, math.log10(1 + ol_ec)) / n_ol
+        confidence = min(total_weight / denom, 1.0) if denom > 0 else 0.0
+        composite = confidence * demand_score + (1 - confidence) * ol_norm
+        if confidence == 0:
+            composite = min(composite, 0.5)
+
+        work_composites[work] = composite
+
+    # Compute filler scores from in-memory composites (top-3 mean)
+    filler_works, filler_freq = _load_filler_works(conn)
+
+    filler_updates = []  # (popularity_score, popularity_level, filler_id)
+    for fid, wkeys in filler_works.items():
+        scores = sorted([work_composites.get(wk, 0.0) for wk in wkeys], reverse=True)
+        top3 = scores[:3]
+        avg = sum(top3) / len(top3) if top3 else 0.0
+        filler_updates.append((avg, 1, 1.0, fid))
+
+    # Fallback for fillers without L1 data
+    l1_ids = set(filler_works.keys())
+    for fid, freq in filler_freq.items():
+        if fid not in l1_ids:
+            score = math.log10(1 + freq) if freq > 0 else 0.0
+            filler_updates.append((score, 0, 0.0, fid))
+
+    # Write only filler scores to DB (~13k rows)
+    conn.executemany(
+        "UPDATE slot_fillers SET popularity_score=?, popularity_level=?, popularity_confidence=? WHERE id=?",
+        filler_updates,
+    )
+    conn.commit()
+
+    elapsed = _time.time() - t0
+    click.echo(f"  [repopulate] scored {len(all_works):,} works in memory, "
+               f"updated {len(filler_updates):,} fillers in {elapsed:.0f}s")
+    return work_composites
+
+
+def _run_repopulate_full(conn: sqlite3.Connection):
+    """Full repopulate: recompute and write everything to DB (for 'keep' path)."""
+    import importlib
+    import time as _time
+
+    click.echo("  [repopulate] full DB write...")
+    t0 = _time.time()
+
+    data = _load_pop_data()
+    cfg = load_tuning_config(conn)
+
+    w_spl = cfg.get("pop_weight_spl", 0.7)
+    w_ol = cfg.get("pop_weight_ol", 0.3)
+    w_gr = cfg.get("pop_weight_gr", 0.2)
+    w_library = cfg.get("pop_weight_library", 0.05)
+    w_nyt = cfg.get("pop_weight_nyt", 0.1)
+    w_trove = cfg.get("pop_weight_trove", 0.05)
+    exponent = cfg.get("pop_exponent", 1.2)
+
+    sys.path.insert(0, "data")
+    import populate_popularity as pp
+    importlib.reload(pp)
+
+    conn.execute("PRAGMA synchronous=OFF")
+    conn.execute("PRAGMA cache_size=-65536")
+    conn.execute("PRAGMA mmap_size=268435456")
+    conn.execute("PRAGMA temp_store=MEMORY")
+
+    pp.create_tables(conn)
+    pp.populate_work_level(
+        conn, data["spl"], data["ol"],
+        w_spl=w_spl, w_ol=w_ol, exponent=exponent,
+        gr=data["gr"], w_gr=w_gr,
+        ottawa_isbn=data["ottawa_isbn"], w_library=w_library,
+        nyt=data["nyt"], w_nyt=w_nyt,
+        trove_isbn=data["trove"], w_trove=w_trove,
+        work_data_cache=_work_data_cache,
+    )
+    pp.score_fillers_level1(conn)
+    pp.score_fillers_fallback(conn)
+
+    elapsed = _time.time() - t0
+    click.echo(f"  [repopulate] full write done in {elapsed:.0f}s")
+    _run_calibrate_thresholds(conn)
+
+
+def _run_repopulate(conn: sqlite3.Connection):
+    """Fast repopulate: score in memory, write only filler scores."""
+    result = _score_in_memory(conn)
+    if result is not None:
+        # Fast in-memory path; cold-start path (result is None) already
+        # delegated to _run_repopulate_full which calibrated.
+        _run_calibrate_thresholds(conn)
 
 
 def _load_goals() -> str:

--- a/tests/test_pipeline_characterization.py
+++ b/tests/test_pipeline_characterization.py
@@ -42,6 +42,8 @@ EXPECTED_TUNABLE_PARAMS = {
     "pop_weight_gr": 0.2,
     "pop_weight_nyt": 0.1,
     "pop_weight_library": 0.05,
+    "pop_weight_trove": 0.05,
+    "pop_weight_freq": 0.0,
     "pop_exponent": 1.2,
     "pop_base_weight_blend": 0.5,
     "pop_classification_blend": 0.9,
@@ -177,7 +179,9 @@ def test_observed_pipeline_schema_columns(tmp_path):
         "work_key", "spl_checkouts", "spl_years", "spl_earliest_pub_year",
         "ol_edition_count", "checkouts_per_year", "editions_per_decade",
         "gr_ratings_count", "gr_average_rating", "nyt_weeks_on_list",
-        "nyt_peak_rank", "library_appearances", "composite_score",
+        "nyt_peak_rank", "library_appearances", "trove_library_count",
+        "trove_holding_count", "trove_copy_count", "trove_copy_count_is_exact",
+        "composite_score",
     }
     assert _columns(conn, "config") == {"key", "value"}
     assert _columns(conn, "human_ratings") >= {
@@ -204,6 +208,7 @@ def test_work_level_popularity_scoring_is_testable_without_db_writes():
         },
         work_ottawa={},
         work_nyt={"work-a": {"weeks_on_list": 4, "peak_rank": 3}},
+        work_trove={},
         all_works={"work-a", "work-b", "work-c"},
     )
     percentiles = pop.build_percentile_models(data)
@@ -213,6 +218,8 @@ def test_work_level_popularity_scoring_is_testable_without_db_writes():
         weight_goodreads=0.2,
         weight_nyt=0.1,
         weight_library=0.05,
+        weight_trove=0.05,
+        weight_frequency=0.0,
         exponent=1.2,
     )
 
@@ -400,6 +407,7 @@ def test_parameter_views_preserve_defaults_and_db_overrides():
 
     assert popularity.weight_spl == 0.9
     assert popularity.weight_ol == EXPECTED_TUNABLE_PARAMS["pop_weight_ol"]
+    assert popularity.weight_trove == EXPECTED_TUNABLE_PARAMS["pop_weight_trove"]
     assert blends.classification_blend == 0.25
     assert get_slot_multiplier_parameters(conn).of_object == 1.4
     assert get_generation_tier_ratios(conn).pop == 0.0183

--- a/tests/test_popularity.py
+++ b/tests/test_popularity.py
@@ -1081,7 +1081,9 @@ def test_config_params_exist():
     from subtitle_generator.config import ALL_TUNABLE_PARAMS
 
     expected = [
-        "pop_weight_spl", "pop_weight_ol",
+        "pop_weight_spl", "pop_weight_ol", "pop_weight_gr",
+        "pop_weight_nyt", "pop_weight_library", "pop_weight_trove",
+        "pop_weight_freq",
         "pop_exponent", "pop_base_weight_blend", "pop_classification_blend",
         "pop_missing_default", "default_generation_tone_target",
         "tier_pop_min_demand_confidence",

--- a/tests/test_trove_stream.py
+++ b/tests/test_trove_stream.py
@@ -1,0 +1,211 @@
+"""Tests for Trove Australia holdings normalization."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+def _load_trove_stream_module():
+    module_path = Path(__file__).parent.parent / "data" / "trove_stream.py"
+    spec = importlib.util.spec_from_file_location("trove_stream", module_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_populate_popularity_module():
+    module_path = Path(__file__).parent.parent / "data" / "populate_popularity.py"
+    spec = importlib.util.spec_from_file_location("populate_popularity", module_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_normalize_work_uses_holdings_count_proxy():
+    trove = _load_trove_stream_module()
+    work = {
+        "id": "6311198",
+        "title": "A short history of Australia / Manning Clark",
+        "contributor": ["Clark, Manning"],
+        "identifier": [{"type": "ISBN", "value": "0333337352"}],
+        "holdingsCount": 179,
+        "versionCount": 115,
+        "holding": [
+            {"nuc": "TSL", "url": {"type": "deepLink", "value": "https://example.test/tsl"}},
+            {"nuc": "ANL", "url": {"type": "deepLink", "value": "https://example.test/anl"}},
+            {"nuc": "TSL"},
+        ],
+        "version": [{"id": "v1", "holdingsCount": 34}],
+    }
+
+    lookup = trove.normalize_work(work, include_libraries=True, checked_at="2026-05-02T00:00:00Z")
+
+    assert "0333337352" in lookup
+    assert "9780333337356" in lookup
+    entry = lookup["0333337352"]
+    assert entry["trove_work_id"] == "6311198"
+    assert entry["library_count"] == 179
+    assert entry["holding_count"] == 179
+    assert entry["copy_count"] == 179
+    assert entry["copy_count_is_exact"] is False
+    assert entry["copy_count_basis"] == "holdings_count_proxy"
+    assert entry["libraries"] == ["ANL", "TSL"]
+    assert entry["version_holding_count"] == 34
+
+
+def test_normalize_work_recursively_extracts_record_isbns():
+    trove = _load_trove_stream_module()
+    work = {
+        "id": "10000002",
+        "title": "Nested ISBN example",
+        "holdingsCount": "3",
+        "version": [
+            {
+                "record": [
+                    {
+                        "metadata": {
+                            "dc": {
+                                "identifier": [
+                                    {"type": "ISBN", "value": "978-1-56619-909-4"},
+                                    {"type": "control number", "value": "6736788"},
+                                ]
+                            }
+                        }
+                    }
+                ]
+            }
+        ],
+    }
+
+    lookup = trove.normalize_work(work)
+
+    assert list(lookup) == ["9781566199094"]
+    assert lookup["9781566199094"]["library_count"] == 3
+
+
+def test_load_trove_maps_isbn_to_work_key():
+    pop = _load_populate_popularity_module()
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE isbn_aliases (isbn TEXT, work_key TEXT)")
+    conn.executemany(
+        "INSERT INTO isbn_aliases VALUES (?, ?)",
+        [
+            ("9780333337359", "work-a"),
+            ("9781566199094", "work-b"),
+        ],
+    )
+
+    work_trove = pop.load_trove(
+        conn,
+        {
+            "9780333337359": {
+                "library_count": 179,
+                "holding_count": 179,
+                "copy_count": 179,
+                "copy_count_is_exact": False,
+            },
+            "9781566199094": {
+                "library_count": 3,
+                "holding_count": 3,
+                "copy_count": 3,
+                "copy_count_is_exact": False,
+            },
+        },
+    )
+
+    assert work_trove["work-a"]["library_count"] == 179
+    assert work_trove["work-b"]["holding_count"] == 3
+
+
+def test_download_by_isbn_propagates_quota_without_marking_processed(tmp_path):
+    trove = _load_trove_stream_module()
+
+    class QuotaClient:
+        def search(self, *_args, **_kwargs):
+            raise trove.TroveQuotaExceeded("Reached --max-requests=1")
+
+    checkpoint: dict = {}
+
+    with pytest.raises(trove.TroveQuotaExceeded):
+        trove.download_by_isbn(
+            QuotaClient(),
+            {"9780333337356"},
+            {},
+            checkpoint,
+            limit=None,
+            refresh_days=30,
+            fetch_details=False,
+            include_libraries=False,
+            save_every=25,
+            workers=1,
+            output_path=tmp_path / "lookup.json",
+            checkpoint_path=tmp_path / "checkpoint.json",
+        )
+
+    assert checkpoint["processed_isbns"] == []
+    assert checkpoint["failed_isbns"] == {}
+
+
+def test_download_by_isbn_does_not_mark_transient_failure_processed(tmp_path):
+    trove = _load_trove_stream_module()
+
+    class FailingClient:
+        def search(self, *_args, **_kwargs):
+            raise RuntimeError("HTTP 503 after retries")
+
+    checkpoint: dict = {}
+
+    trove.download_by_isbn(
+        FailingClient(),
+        {"9780333337356"},
+        {},
+        checkpoint,
+        limit=None,
+        refresh_days=30,
+        fetch_details=False,
+        include_libraries=False,
+        save_every=25,
+        workers=1,
+        output_path=tmp_path / "lookup.json",
+        checkpoint_path=tmp_path / "checkpoint.json",
+    )
+
+    assert checkpoint["processed_isbns"] == []
+    assert checkpoint["failed_isbns"] == {"9780333337356": "HTTP 503 after retries"}
+
+
+def test_download_by_isbn_final_checkpoint_includes_last_partial_batch(tmp_path):
+    trove = _load_trove_stream_module()
+
+    class NotFoundClient:
+        def search(self, *_args, **_kwargs):
+            return []
+
+    checkpoint: dict = {}
+    checkpoint_path = tmp_path / "checkpoint.json"
+
+    trove.download_by_isbn(
+        NotFoundClient(),
+        {"9780333337356"},
+        {},
+        checkpoint,
+        limit=None,
+        refresh_days=30,
+        fetch_details=False,
+        include_libraries=False,
+        save_every=25,
+        workers=1,
+        output_path=tmp_path / "lookup.json",
+        checkpoint_path=checkpoint_path,
+    )
+
+    saved_checkpoint = json.loads(checkpoint_path.read_text(encoding="utf-8"))
+    assert saved_checkpoint["processed_isbns"] == ["9780333337356"]
+    assert saved_checkpoint["failed_isbns"] == {}

--- a/uv.lock
+++ b/uv.lock
@@ -1721,7 +1721,7 @@ wheels = [
 
 [[package]]
 name = "subtitle-generator"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

| Area | Change |
| --- | --- |
| Trove download | Add `data/trove_stream.py` for Trove Australia ISBN holdings lookup generation with rate limiting, retries, resumable checkpoints, targeted DB ISBN loading, CSV import, and optional library-code capture. |
| Popularity scoring | Add Trove work-level fields and `pop_weight_trove` integration through DB population, filler scoring, tuning, config, parameter state, and schema contracts. |
| CLI/docs | Add Trove options to `download-popularity` and `populate-popularity`; document Trove as an optional popularity source. |
| Safety/tests | Cover holdings normalization, recursive ISBN extraction, Trove work-key mapping, request-limit resume safety, transient fetch retry behavior, and final checkpoint persistence. |

## Validation

- `uv run pytest` — 132 passed
- `uv run ruff check` — passed
- `uv run ty check` — passed
- Populated the local full SQLite DB with the generated Trove lookup: 6,400 works with nonzero Trove signal.

## Data / backup

Generated Trove artifacts are not committed. The completed lookup/checkpoint/manifest were backed up under `subtitlegenst/data-backup/trove/2026-05-03/`.

## Breaking changes

None expected. Trove is optional and defaults to the configured `pop_weight_trove` when the lookup file is present.