### PR TITLE
fix: persist web ratings to Azure Tables

### DIFF
--- a/api/function_app.py
+++ b/api/function_app.py
@@ -3,6 +3,8 @@
 # ruff: noqa: E402
 
 import json
+import logging
+import os
 import sys
 from pathlib import Path
 
@@ -19,9 +21,15 @@ from subtitle_generator.handlers import (
     handle_health,
     handle_jacket,
     handle_rate,
+    validate_rating_body,
+)
+from subtitle_generator.rating_storage import (
+    RatingTableWriteError,
+    write_rating_to_table_storage,
 )
 
 app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+logger = logging.getLogger(__name__)
 
 
 def _json_response(body: dict, status_code: int = 200) -> func.HttpResponse:
@@ -75,6 +83,26 @@ def jacket(req: func.HttpRequest) -> func.HttpResponse:
 # ── POST /api/rate ──────────────────────────────────────────────────
 
 
+def _handle_rate_azure(body: dict) -> tuple[int, dict]:
+    status, resp, payload = validate_rating_body(body)
+    if status != 200:
+        return status, resp
+    assert payload is not None
+
+    entity = write_rating_to_table_storage(
+        payload.subtitle,
+        payload.thumbs,
+        payload.tone_override,
+        payload.free_text,
+        payload.system_tone,
+        payload.tags,
+        source=payload.source,
+        prompt_generated=payload.prompt_generated,
+        required=True,
+    )
+    return 200, {"id": entity["RowKey"], "status": "saved"}
+
+
 @app.route(route="rate", methods=["POST"])
 def rate(req: func.HttpRequest) -> func.HttpResponse:
     try:
@@ -83,10 +111,30 @@ def rate(req: func.HttpRequest) -> func.HttpResponse:
         except ValueError:
             return _error("Request body must be valid JSON")
 
-        status, resp = handle_rate(body)
+        try:
+            if os.environ.get("SUBTITLE_GEN_MODE") == "azure":
+                status, resp = _handle_rate_azure(body)
+            else:
+                status, resp = handle_rate(body)
+                if status == 200:
+                    write_rating_to_table_storage(
+                        body.get("subtitle", ""),
+                        body.get("thumbs"),
+                        body.get("tone_override"),
+                        body.get("free_text"),
+                        body.get("system_tone"),
+                        body.get("tags"),
+                        source=body.get("_source", "web_user"),
+                        prompt_generated=body.get("prompt_generated", False),
+                        required=False,
+                    )
+        except RatingTableWriteError:
+            logger.exception("Failed to persist rating to Azure Table Storage")
+            return _error("Failed to persist rating to durable storage", 500)
         return _json_response(resp, status)
 
     except Exception as exc:
+        logger.exception("Unhandled rate request error")
         return _error(f"Internal error: {exc}", 500)
 
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,4 +1,6 @@
 click>=8.3.2
 azure-functions
+azure-data-tables>=12.5
+azure-identity>=1.25
 inflect>=7.0
 titlecase>=2.4

--- a/docs/pipeline-end-to-end.md
+++ b/docs/pipeline-end-to-end.md
@@ -740,7 +740,7 @@ change. It can include:
 - thumbs up/down
 - system tone
 - human tone override
-- tags such as `interesting`, `realistic`, `funny`, `boring`, `broken`, and
+- tags such as `interesting`, `realistic`, `funny`, `boring`, `broken syntax`, and
   `nonsense`
 - free text
 - config snapshot

--- a/infra/modules/functionapp.bicep
+++ b/infra/modules/functionapp.bicep
@@ -113,5 +113,17 @@ resource funcBlobRbac 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   }
 }
 
+// RBAC: Storage Table Data Contributor for durable rating feedback writes
+var storageTableDataContributorRole = '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3'
+resource funcTableRbac 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storageAccount.id, functionApp.id, storageTableDataContributorRole)
+  scope: storageAccount
+  properties: {
+    principalId: functionApp.identity.principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageTableDataContributorRole)
+    principalType: 'ServicePrincipal'
+  }
+}
+
 output functionAppName string = functionApp.name
 output functionAppPrincipalId string = functionApp.identity.principalId

--- a/infra/modules/storage.bicep
+++ b/infra/modules/storage.bicep
@@ -37,8 +37,19 @@ resource webContainer 'Microsoft.Storage/storageAccounts/blobServices/containers
   }
 }
 
+resource tableService 'Microsoft.Storage/storageAccounts/tableServices@2023-05-01' = {
+  parent: storageAccount
+  name: 'default'
+}
+
+resource ratingsTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2023-05-01' = {
+  parent: tableService
+  name: 'ratings'
+}
+
 // Optional: RBAC for developer principal
 var storageBlobDataContributorRole = 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
+var storageTableDataContributorRole = '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3'
 
 resource devBlobRbac 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(principalId)) {
   name: guid(storageAccount.id, principalId, storageBlobDataContributorRole)
@@ -46,6 +57,16 @@ resource devBlobRbac 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (
   properties: {
     principalId: principalId
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageBlobDataContributorRole)
+    principalType: 'User'
+  }
+}
+
+resource devTableRbac 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(principalId)) {
+  name: guid(storageAccount.id, principalId, storageTableDataContributorRole)
+  scope: storageAccount
+  properties: {
+    principalId: principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageTableDataContributorRole)
     principalType: 'User'
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "subtitle-generator"
-version = "0.6.0"
+version = "0.6.1"
 description = "Generate bizarre book subtitles by mixing real parts from Library of Congress MARC records"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -17,7 +17,7 @@ dependencies = [
 
 [project.optional-dependencies]
 tune = ["litellm>=1.72.0", "pydantic>=2.0"]
-deploy = ["azure-data-tables>=12.5"]
+deploy = ["azure-data-tables>=12.5", "azure-identity>=1.25"]
 e2e = ["playwright>=1.56.0"]
 
 [project.scripts]

--- a/src/subtitle_generator/__init__.py
+++ b/src/subtitle_generator/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("subtitle-generator")
 except PackageNotFoundError:
-    __version__ = "0.6.0"
+    __version__ = "0.6.1"

--- a/src/subtitle_generator/cli.py
+++ b/src/subtitle_generator/cli.py
@@ -2,7 +2,9 @@
 
 import sqlite3
 import sys
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Iterable
 
 import click
 
@@ -37,6 +39,21 @@ _VALID_TONES = set(_TONE_CHOICES.keys())
 _TONE_OVERRIDE_MAP = {"p": "pop", "m": "mainstream", "n": "niche"}
 
 
+@dataclass
+class RatingSyncStats:
+    synced: int = 0
+    duplicate: int = 0
+    filtered: int = 0
+    malformed: int = 0
+
+
+def _get_command_conn(ctx) -> tuple[sqlite3.Connection, bool]:
+    """Return the CLI context connection when present, else the default DB."""
+    if ctx.obj and "conn" in ctx.obj:
+        return ctx.obj["conn"], False
+    return get_db(), True
+
+
 def _get_system_tone(subtitle: str, conn) -> tuple[str, float]:
     """Compute system tone tier and score for a subtitle."""
     evidence = compute_tier_evidence(subtitle, conn)
@@ -46,7 +63,7 @@ def _get_system_tone(subtitle: str, conn) -> tuple[str, float]:
 _TAG_MAP = {
     "f": "funny",
     "b": "boring",
-    "r": "broken",
+    "r": "broken syntax",
     "n": "nonsense",
     "l": "realistic",
     "i": "interesting",
@@ -83,7 +100,7 @@ def _prompt_review(conn, subtitle_text: str) -> int | None:
 
     # Tags
     tags_input = click.prompt(
-        click.style("     Tags? [f=funny / b=boring / r=broken / n=nonsense / l=realistic / i=interesting / Enter]", fg="cyan"),
+        click.style("     Tags? [f=funny / b=boring / r=broken syntax / n=nonsense / l=realistic / i=interesting / Enter]", fg="cyan"),
         default="", show_default=False,
     ).strip().lower()
     tags = [_TAG_MAP[c] for c in tags_input if c in _TAG_MAP] or None
@@ -715,10 +732,13 @@ def spot_check_cmd(ctx, samples: int, source: str):
       subtitle-gen spot-check              # CLI mode, 2 per tier
       subtitle-gen spot-check --samples 3  # 3 per tier = 9 total
     """
-    conn = ctx.obj["conn"]
+    conn, should_close = _get_command_conn(ctx)
     from subtitle_generator.tune import run_spot_check
-    run_spot_check(conn, n_samples=samples, source=source)
-    conn.close()
+    try:
+        run_spot_check(conn, n_samples=samples, source=source)
+    finally:
+        if should_close:
+            conn.close()
 
 
 @cli.command("review-ratings")
@@ -740,11 +760,104 @@ def review_ratings_cmd(ctx, since: str | None, source: str | None, model: str | 
       subtitle-gen review-ratings --source web_user   # end-user only
       subtitle-gen review-ratings --since 2026-04-15  # since date
     """
-    conn = ctx.obj["conn"]
+    conn, should_close = _get_command_conn(ctx)
     from subtitle_generator.tune import review_ratings
     from subtitle_generator.eval_harness import DEFAULT_PROPOSER_MODEL
-    review_ratings(conn, since=since, source=source, model=model or DEFAULT_PROPOSER_MODEL)
-    conn.close()
+    try:
+        review_ratings(conn, since=since, source=source, model=model or DEFAULT_PROPOSER_MODEL)
+    finally:
+        if should_close:
+            conn.close()
+
+
+def _existing_remote_rating_keys(conn: sqlite3.Connection) -> set[str]:
+    """Return RowKeys already imported into human_ratings.config_snapshot."""
+    existing: set[str] = set()
+    rows = conn.execute(
+        "SELECT DISTINCT config_snapshot FROM human_ratings WHERE config_snapshot LIKE '%RowKey%'"
+    ).fetchall()
+    import json as _json
+    for (snap,) in rows:
+        try:
+            parsed = _json.loads(snap)
+        except (_json.JSONDecodeError, TypeError):
+            continue
+        if isinstance(parsed, dict) and isinstance(parsed.get("RowKey"), str):
+            existing.add(parsed["RowKey"])
+    return existing
+
+
+def _sync_rating_entities(conn: sqlite3.Connection, entities: Iterable[dict]) -> RatingSyncStats:
+    """Import Azure Table rating entities into local SQLite with validation."""
+    import json as _json
+
+    from subtitle_generator.feedback import (
+        ensure_ratings_table,
+        parse_rating_tags,
+        rating_tags_are_current,
+        store_rating,
+    )
+
+    ensure_ratings_table(conn)
+    existing = _existing_remote_rating_keys(conn)
+    stats = RatingSyncStats()
+
+    for entity in entities:
+        row_key = entity.get("RowKey")
+        if not isinstance(row_key, str) or not row_key:
+            stats.malformed += 1
+            continue
+        if row_key in existing:
+            stats.duplicate += 1
+            continue
+
+        subtitle = entity.get("subtitle")
+        if not isinstance(subtitle, str) or not subtitle:
+            stats.malformed += 1
+            continue
+
+        try:
+            tags = parse_rating_tags(entity.get("tags", "[]"))
+        except ValueError:
+            stats.malformed += 1
+            continue
+        if not rating_tags_are_current(tags):
+            stats.filtered += 1
+            continue
+
+        thumbs_val = entity.get("thumbs")
+        if thumbs_val in ("", None):
+            thumbs_val = None
+        else:
+            try:
+                thumbs_val = int(thumbs_val)
+            except (TypeError, ValueError):
+                stats.malformed += 1
+                continue
+            if thumbs_val not in (1, -1):
+                stats.malformed += 1
+                continue
+
+        store_rating(
+            conn,
+            subtitle,
+            system_tone=entity.get("system_tone") or None,
+            thumbs=thumbs_val,
+            tone_override=entity.get("tone_override") or None,
+            free_text=entity.get("free_text") or None,
+            tags=tags,
+            source="pull_ratings",
+            prompt_generated=bool(entity.get("prompt_generated", False)),
+        )
+        conn.execute(
+            "UPDATE human_ratings SET config_snapshot = ? WHERE id = last_insert_rowid()",
+            (_json.dumps({"RowKey": row_key}),),
+        )
+        conn.commit()
+        existing.add(row_key)
+        stats.synced += 1
+
+    return stats
 
 
 @cli.command()
@@ -1040,26 +1153,7 @@ def pull_ratings_cmd(ctx, since: str | None, account: str | None):
             "azure-data-tables not installed. Run: uv pip install azure-data-tables azure-identity"
         )
 
-    conn = ctx.obj["conn"]
-    from subtitle_generator.feedback import ensure_ratings_table, store_rating
-    ensure_ratings_table(conn)
-
-    # Get existing RowKeys to deduplicate
-    existing = set()
-    try:
-        rows = conn.execute(
-            "SELECT DISTINCT config_snapshot FROM human_ratings WHERE config_snapshot LIKE '%RowKey%'"
-        ).fetchall()
-        import json as _json
-        for (snap,) in rows:
-            try:
-                d = _json.loads(snap)
-                if "RowKey" in d:
-                    existing.add(d["RowKey"])
-            except Exception:
-                pass
-    except Exception:
-        pass
+    conn, should_close = _get_command_conn(ctx)
 
     credential = DefaultAzureCredential()
     service = TableServiceClient(
@@ -1068,48 +1162,22 @@ def pull_ratings_cmd(ctx, since: str | None, account: str | None):
     )
     table = service.get_table_client("ratings")
 
-    import json as _json
     query_filter = None
     if since:
         query_filter = f"RowKey ge '{since}'"
 
-    synced = 0
-    skipped = 0
-    for entity in table.list_entities(filter=query_filter):
-        row_key = entity["RowKey"]
-        if row_key in existing:
-            skipped += 1
-            continue
-
-        tags_raw = entity.get("tags", "[]")
-        try:
-            tags = _json.loads(tags_raw)
-        except Exception:
-            tags = None
-
-        thumbs_val = entity.get("thumbs")
-        if thumbs_val is not None:
-            thumbs_val = int(thumbs_val)
-
-        store_rating(
-            conn,
-            entity.get("subtitle", ""),
-            system_tone=entity.get("system_tone") or None,
-            thumbs=thumbs_val,
-            tone_override=entity.get("tone_override") or None,
-            free_text=entity.get("free_text") or None,
-            tags=tags,
-            source="pull_ratings",
-        )
-        # Store RowKey in config_snapshot for dedup on next sync
-        conn.execute(
-            "UPDATE human_ratings SET config_snapshot = ? WHERE id = last_insert_rowid()",
-            (_json.dumps({"RowKey": row_key}),),
-        )
-        conn.commit()
-        synced += 1
-
-    click.echo(f"Synced {synced} ratings ({skipped} duplicates skipped).")
+    try:
+        stats = _sync_rating_entities(conn, table.list_entities(filter=query_filter))
+    finally:
+        if should_close:
+            conn.close()
+    click.echo(
+        "Synced "
+        f"{stats.synced} ratings "
+        f"({stats.duplicate} duplicates skipped, "
+        f"{stats.filtered} stale tag sets filtered, "
+        f"{stats.malformed} malformed rows skipped)."
+    )
 
 
 _POP_SOURCES = ["spl", "ol", "gr", "ottawa", "nyt", "trove"]

--- a/src/subtitle_generator/feedback.py
+++ b/src/subtitle_generator/feedback.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import sqlite3
 from collections import Counter
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -19,11 +20,41 @@ from subtitle_generator.config import load_tuning_config
 VALID_RATING_TAGS = frozenset({
     "funny",
     "boring",
-    "broken",
+    "broken syntax",
     "nonsense",
     "realistic",
     "interesting",
 })
+
+LEGACY_RATING_TAG_ALIASES = {
+    "broken": "broken syntax",
+}
+
+
+def normalize_rating_tags(tags: list[str]) -> list[str]:
+    """Normalize legacy rating tag names to current canonical tags."""
+    return [LEGACY_RATING_TAG_ALIASES.get(tag, tag) for tag in tags]
+
+
+def parse_rating_tags(value: Any) -> list[str]:
+    """Parse and validate a rating tag payload from JSON or Table Storage."""
+    if value in (None, ""):
+        return []
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise ValueError("tags must be valid JSON") from exc
+    else:
+        parsed = value
+    if not isinstance(parsed, list) or not all(isinstance(tag, str) for tag in parsed):
+        raise ValueError("tags must be an array of strings")
+    return normalize_rating_tags(parsed)
+
+
+def rating_tags_are_current(tags: list[str]) -> bool:
+    """Return true when a rating's tags are all current supported options."""
+    return not (set(tags) - VALID_RATING_TAGS)
 
 # ---------------------------------------------------------------------------
 # Pydantic schemas
@@ -65,6 +96,8 @@ def ensure_ratings_table(conn: sqlite3.Connection) -> None:
         conn.execute("ALTER TABLE human_ratings ADD COLUMN tags TEXT DEFAULT '[]'")
     if "source" not in cols:
         conn.execute("ALTER TABLE human_ratings ADD COLUMN source TEXT DEFAULT 'unknown'")
+    if "prompt_generated" not in cols:
+        conn.execute("ALTER TABLE human_ratings ADD COLUMN prompt_generated INTEGER DEFAULT 0")
     conn.commit()
 
 
@@ -83,6 +116,7 @@ def store_rating(
     free_text: str | None = None,
     tags: list[str] | None = None,
     source: str = "unknown",
+    prompt_generated: bool = False,
 ) -> int:
     """Store a human rating. Returns the row id.
 
@@ -94,6 +128,7 @@ def store_rating(
         free_text: Optional free-text comment.
         tags: Quality tags like ["interesting", "realistic", "funny", "boring"].
         source: Origin of this rating ("spot_check", "web_user", "pull_ratings").
+        prompt_generated: Whether the user generated a jacket prompt for this subtitle.
     """
     ensure_ratings_table(conn)
 
@@ -114,10 +149,10 @@ def store_rating(
     cur = conn.execute(
         """INSERT INTO human_ratings
            (subtitle, system_tone, thumbs, tone_override, free_text,
-            interpreted, config_snapshot, tags, source)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+             interpreted, config_snapshot, tags, source, prompt_generated)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (subtitle, system_tone, thumbs, tone_override, free_text,
-         interpreted, config_snapshot, tags_json, source),
+         interpreted, config_snapshot, tags_json, source, int(prompt_generated)),
     )
     conn.commit()
     return cur.lastrowid
@@ -171,7 +206,7 @@ def get_summary(
     ensure_ratings_table(conn)
 
     rows = conn.execute(
-        """SELECT thumbs, system_tone, tone_override, free_text, interpreted, tags
+        """SELECT thumbs, system_tone, tone_override, free_text, interpreted, tags, prompt_generated
            FROM human_ratings
            ORDER BY created_at DESC
            LIMIT ?""",
@@ -218,6 +253,7 @@ def get_summary(
 
     # Tag counts
     tag_counter: Counter = Counter()
+    prompt_generated_count = 0
     for r in rows:
         tags_str = r[5] if len(r) > 5 and r[5] else "[]"
         try:
@@ -226,6 +262,8 @@ def get_summary(
                 tag_counter[tag] += 1
         except (json.JSONDecodeError, TypeError):
             pass
+        if len(r) > 6 and r[6]:
+            prompt_generated_count += 1
 
     return {
         "total_ratings": len(rows),
@@ -237,6 +275,7 @@ def get_summary(
         "recent_comments": recent_comments[:5],
         "interpreted_insights": interpreted_insights[:5],
         "tag_counts": dict(tag_counter.most_common()),
+        "prompt_generated_count": prompt_generated_count,
     }
 
 
@@ -269,5 +308,7 @@ def format_summary_for_proposer(summary: dict) -> str:
     if summary.get("tag_counts"):
         tag_strs = ", ".join(f"{count}× {tag}" for tag, count in summary["tag_counts"].items())
         lines.append(f"- Quality tags: {tag_strs}")
+    if summary.get("prompt_generated_count"):
+        lines.append(f"- Prompt generated: {summary['prompt_generated_count']}×")
 
     return "\n".join(lines)

--- a/src/subtitle_generator/handlers.py
+++ b/src/subtitle_generator/handlers.py
@@ -7,6 +7,7 @@ its own response type.
 
 import os
 import sqlite3
+from dataclasses import dataclass
 from pathlib import Path
 
 from subtitle_generator.generate import (
@@ -29,6 +30,18 @@ from subtitle_generator.jacket import (
 
 TONE_CHOICES = {"pop": TONE_HIGH, "mainstream": TONE_MEDIUM, "niche": TONE_LOW}
 VALID_TONES = set(TONE_CHOICES.keys())
+
+
+@dataclass(frozen=True)
+class RatingPayload:
+    subtitle: str
+    thumbs: int | None
+    tone_override: str | None
+    free_text: str | None
+    system_tone: str | None
+    tags: list[str] | None
+    source: str
+    prompt_generated: bool
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -184,20 +197,20 @@ def handle_jacket(body: dict) -> tuple[int, dict]:
         conn.close()
 
 
-def handle_rate(body: dict) -> tuple[int, dict]:
-    """Store a human rating for a subtitle."""
+def validate_rating_body(body: dict) -> tuple[int, dict, RatingPayload | None]:
+    """Validate a rating request body without writing to local storage."""
     subtitle = body.get("subtitle")
     if not subtitle or not isinstance(subtitle, str):
-        return 400, {"error": "subtitle is required and must be a non-empty string"}
+        return 400, {"error": "subtitle is required and must be a non-empty string"}, None
 
     thumbs = body.get("thumbs")
     if thumbs is not None:
         if thumbs not in (1, -1):
-            return 400, {"error": "thumbs must be 1 (up) or -1 (down)"}
+            return 400, {"error": "thumbs must be 1 (up) or -1 (down)"}, None
 
     tone_override = body.get("tone_override")
     if tone_override and tone_override not in ("pop", "mainstream", "niche"):
-        return 400, {"error": "tone_override must be pop, mainstream, or niche"}
+        return 400, {"error": "tone_override must be pop, mainstream, or niche"}, None
 
     free_text = body.get("free_text")
     system_tone = body.get("system_tone")
@@ -205,29 +218,61 @@ def handle_rate(body: dict) -> tuple[int, dict]:
     tags = body.get("tags")
     if tags is not None:
         if not isinstance(tags, list) or not all(isinstance(t, str) for t in tags):
-            return 400, {"error": "tags must be an array of strings"}
-        from subtitle_generator.feedback import VALID_RATING_TAGS
+            return 400, {"error": "tags must be an array of strings"}, None
+        from subtitle_generator.feedback import VALID_RATING_TAGS, normalize_rating_tags
 
+        tags = normalize_rating_tags(tags)
         invalid_tags = set(tags) - VALID_RATING_TAGS
         if invalid_tags:
-            return 400, {"error": f"Invalid tags: {', '.join(invalid_tags)}"}
+            return 400, {"error": f"Invalid tags: {', '.join(invalid_tags)}"}, None
 
     source = body.get("_source", "web_user")
+    if not isinstance(source, str) or not source:
+        source = "web_user"
 
+    prompt_generated = body.get("prompt_generated", False)
+    if not isinstance(prompt_generated, bool):
+        return 400, {"error": "prompt_generated must be a boolean"}, None
+
+    return 200, {"status": "validated"}, RatingPayload(
+        subtitle=subtitle,
+        thumbs=thumbs,
+        tone_override=tone_override,
+        free_text=free_text if free_text else None,
+        system_tone=system_tone,
+        tags=tags,
+        source=source,
+        prompt_generated=prompt_generated,
+    )
+
+
+def store_rating_payload(payload: RatingPayload) -> int:
+    """Store a validated rating payload in the local SQLite database."""
     from subtitle_generator.feedback import store_rating
 
     conn = get_db()
     try:
-        row_id = store_rating(
+        return store_rating(
             conn,
-            subtitle,
-            system_tone=system_tone,
-            thumbs=thumbs,
-            tone_override=tone_override,
-            free_text=free_text if free_text else None,
-            tags=tags,
-            source=source,
+            payload.subtitle,
+            system_tone=payload.system_tone,
+            thumbs=payload.thumbs,
+            tone_override=payload.tone_override,
+            free_text=payload.free_text,
+            tags=payload.tags,
+            source=payload.source,
+            prompt_generated=payload.prompt_generated,
         )
-        return 200, {"id": row_id, "status": "saved"}
     finally:
         conn.close()
+
+
+def handle_rate(body: dict) -> tuple[int, dict]:
+    """Store a human rating for a subtitle."""
+    status, resp, payload = validate_rating_body(body)
+    if status != 200:
+        return status, resp
+
+    assert payload is not None
+    row_id = store_rating_payload(payload)
+    return 200, {"id": row_id, "status": "saved"}

--- a/src/subtitle_generator/rating_storage.py
+++ b/src/subtitle_generator/rating_storage.py
@@ -1,0 +1,116 @@
+"""Durable storage helpers for web rating feedback."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+
+RATINGS_TABLE_NAME = "ratings"
+
+logger = logging.getLogger(__name__)
+
+
+class RatingTableWriteError(RuntimeError):
+    """Raised when a required Azure Table Storage rating write fails."""
+
+
+def build_rating_entity(
+    subtitle: str,
+    thumbs: int | None,
+    tone_override: str | None,
+    free_text: str | None,
+    system_tone: str | None,
+    tags: list[str] | None,
+    *,
+    source: str = "web_user",
+    prompt_generated: bool = False,
+    now: datetime | None = None,
+    row_key_suffix: str | None = None,
+) -> dict[str, Any]:
+    """Build the Azure Table entity used for durable rating storage."""
+    timestamp = now or datetime.now(timezone.utc)
+    suffix = row_key_suffix or uuid.uuid4().hex[:8]
+    entity: dict[str, Any] = {
+        "PartitionKey": timestamp.strftime("%Y-%m"),
+        "RowKey": f"{timestamp.isoformat()}-{suffix}",
+        "subtitle": subtitle,
+        "tone_override": tone_override or "",
+        "free_text": free_text or "",
+        "system_tone": system_tone or "",
+        "tags": json.dumps(tags or []),
+        "source": source,
+        "prompt_generated": prompt_generated,
+    }
+    if thumbs is not None:
+        entity["thumbs"] = thumbs
+    return entity
+
+
+def write_rating_to_table_storage(
+    subtitle: str,
+    thumbs: int | None,
+    tone_override: str | None,
+    free_text: str | None,
+    system_tone: str | None,
+    tags: list[str] | None,
+    *,
+    source: str = "web_user",
+    prompt_generated: bool = False,
+    account_name: str | None = None,
+    table_name: str = RATINGS_TABLE_NAME,
+    required: bool = False,
+) -> dict[str, Any] | None:
+    """Write a rating to Azure Table Storage.
+
+    If ``required`` is false, missing configuration is treated as disabled and
+    write errors are logged as best-effort failures. If ``required`` is true,
+    missing configuration, missing dependencies, and Azure write errors raise
+    ``RatingTableWriteError`` so production callers can fail the request.
+    """
+    storage_account = account_name or os.environ.get("STORAGE_ACCOUNT_NAME")
+    if not storage_account:
+        if required:
+            raise RatingTableWriteError("STORAGE_ACCOUNT_NAME is not configured")
+        return None
+
+    entity = build_rating_entity(
+        subtitle,
+        thumbs,
+        tone_override,
+        free_text,
+        system_tone,
+        tags,
+        source=source,
+        prompt_generated=prompt_generated,
+    )
+
+    try:
+        from azure.data.tables import TableServiceClient
+        from azure.identity import DefaultAzureCredential
+    except ImportError as exc:
+        message = "azure-data-tables and azure-identity are required for rating Table Storage writes"
+        if required:
+            raise RatingTableWriteError(message) from exc
+        logger.warning(message, exc_info=True)
+        return None
+
+    try:
+        credential = DefaultAzureCredential()
+        service = TableServiceClient(
+            endpoint=f"https://{storage_account}.table.core.windows.net",
+            credential=credential,
+        )
+        table = service.create_table_if_not_exists(table_name)
+        table.create_entity(entity)
+        return entity
+    except Exception as exc:
+        message = f"Failed to write rating to Azure Table Storage table {table_name!r}"
+        if required:
+            raise RatingTableWriteError(message) from exc
+        logger.warning(message, exc_info=True)
+        return None

--- a/src/subtitle_generator/schema_contracts.py
+++ b/src/subtitle_generator/schema_contracts.py
@@ -77,7 +77,7 @@ SCHEMA_CONTRACTS: tuple[TableContract, ...] = (
         columns=frozenset({
             "id", "subtitle", "system_tone", "thumbs", "tone_override",
             "free_text", "interpreted", "config_snapshot", "created_at",
-            "tags", "source",
+            "tags", "source", "prompt_generated",
         }),
     ),
 )

--- a/src/subtitle_generator/serve.py
+++ b/src/subtitle_generator/serve.py
@@ -6,7 +6,6 @@ without starting the server — call ``create_server()`` or ``run()``.
 
 import asyncio
 import json
-import os
 import random
 import uuid
 from http import HTTPStatus
@@ -26,6 +25,7 @@ from subtitle_generator.handlers import (
     handle_rate as _handle_rate,
 )
 from subtitle_generator.jacket import build_jacket_prompt, generate_jacket_from_prompt
+from subtitle_generator.rating_storage import write_rating_to_table_storage
 
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 _WEB_DIR = _PROJECT_ROOT / "web"
@@ -39,52 +39,18 @@ def _handle_rate_local(body: dict) -> tuple[int, dict]:
     """Wrap shared handle_rate with Azure Table Storage dual-write."""
     status, resp = _handle_rate(body)
     if status == 200:
-        _write_to_table_storage(
+        write_rating_to_table_storage(
             body.get("subtitle", ""),
             body.get("thumbs"),
             body.get("tone_override"),
             body.get("free_text"),
             body.get("system_tone"),
             body.get("tags"),
+            source=body.get("_source", "web_user"),
+            prompt_generated=body.get("prompt_generated", False),
+            required=False,
         )
     return status, resp
-
-
-def _write_to_table_storage(
-    subtitle: str, thumbs: int | None, tone_override: str | None,
-    free_text: str | None, system_tone: str | None, tags: list[str] | None,
-) -> None:
-    """Write rating to Azure Table Storage if STORAGE_ACCOUNT_NAME is set."""
-    account_name = os.environ.get("STORAGE_ACCOUNT_NAME")
-    if not account_name:
-        return
-
-    try:
-        from azure.data.tables import TableServiceClient
-        from azure.identity import DefaultAzureCredential
-        from datetime import datetime, timezone
-
-        credential = DefaultAzureCredential()
-        service = TableServiceClient(
-            endpoint=f"https://{account_name}.table.core.windows.net",
-            credential=credential,
-        )
-        table = service.get_table_client("ratings")
-
-        now = datetime.now(timezone.utc)
-        entity = {
-            "PartitionKey": now.strftime("%Y-%m"),
-            "RowKey": f"{now.isoformat()}-{uuid.uuid4().hex[:8]}",
-            "subtitle": subtitle,
-            "thumbs": thumbs,
-            "tone_override": tone_override or "",
-            "free_text": free_text or "",
-            "system_tone": system_tone or "",
-            "tags": json.dumps(tags or []),
-        }
-        table.create_entity(entity)
-    except Exception:
-        pass  # Non-critical — local SQLite is the primary store
 
 
 # -- /api/spot-check/* (local only) ------------------------------------------

--- a/src/subtitle_generator/tune.py
+++ b/src/subtitle_generator/tune.py
@@ -866,13 +866,13 @@ def _spot_check_cli(
                 ))
 
             tags_input = click.prompt(
-                click.style("       Tags? [f=funny/b=boring/r=broken/n=nonsense/l=realistic/i=interesting / Enter]", fg="cyan"),
+                click.style("       Tags? [f=funny/b=boring/r=broken syntax/n=nonsense/l=realistic/i=interesting / Enter]", fg="cyan"),
                 default="", show_default=False,
             ).strip().lower()
             tag_map = {
                 "f": "funny",
                 "b": "boring",
-                "r": "broken",
+                "r": "broken syntax",
                 "n": "nonsense",
                 "l": "realistic",
                 "i": "interesting",
@@ -923,7 +923,7 @@ def review_ratings(
     from subtitle_generator.feedback import ensure_ratings_table
     ensure_ratings_table(conn)
 
-    query = "SELECT subtitle, system_tone, thumbs, tone_override, tags, source, created_at FROM human_ratings"
+    query = "SELECT subtitle, system_tone, thumbs, tone_override, tags, source, created_at, prompt_generated FROM human_ratings"
     conditions = []
     params = []
     if since:
@@ -951,7 +951,8 @@ def review_ratings(
     tag_counts = Counter()
     mismatch_examples = []
 
-    for sub, sys_tone, thumbs, tone_override, tags_json, src, created in rows:
+    prompt_generated_count = 0
+    for sub, sys_tone, thumbs, tone_override, tags_json, src, created, prompt_generated in rows:
         if sys_tone and tone_override:
             total += 1
             if sys_tone == tone_override:
@@ -963,30 +964,40 @@ def review_ratings(
         tags = _json.loads(tags_json) if tags_json else []
         for tag in tags:
             tag_counts[tag] += 1
+        if prompt_generated:
+            prompt_generated_count += 1
 
-    if total == 0:
-        click.echo("No tone-rated entries found (need system_tone + tone_override).")
-        return
-
-    accuracy = matches / total
-    click.echo(f"  Tone accuracy: {matches}/{total} ({accuracy:.0%})")
+    accuracy = matches / total if total else None
+    if accuracy is not None:
+        click.echo(f"  Tone accuracy: {matches}/{total} ({accuracy:.0%})")
+    else:
+        click.echo("  Tone accuracy: no tone-rated entries (need system_tone + tone_override).")
     click.echo(f"  Tags: {dict(tag_counts.most_common())}")
+    if prompt_generated_count:
+        click.echo(f"  Prompt generated: {prompt_generated_count}")
 
     summary_lines = [
-        f"## Human Rating Analysis ({total} rated samples)",
-        f"Tone accuracy: {matches}/{total} ({accuracy:.0%})",
+        f"## Human Rating Analysis ({len(rows)} ratings)",
         "",
-        "### Mismatch patterns:",
     ]
-    for (system_tone, felt), count in mismatch_directions.most_common():
-        summary_lines.append(f"  target={system_tone} -> felt={felt}: {count}x")
-    summary_lines.append("")
-    summary_lines.append("### Mismatch examples:")
-    for system_tone, felt, sub in mismatch_examples:
-        summary_lines.append(f"  [{system_tone}->{felt}] {sub}")
+    if accuracy is not None:
+        summary_lines.append(f"Tone accuracy: {matches}/{total} ({accuracy:.0%})")
+        summary_lines.append("")
+        summary_lines.append("### Mismatch patterns:")
+        for (system_tone, felt), count in mismatch_directions.most_common():
+            summary_lines.append(f"  target={system_tone} -> felt={felt}: {count}x")
+        summary_lines.append("")
+        summary_lines.append("### Mismatch examples:")
+        for system_tone, felt, sub in mismatch_examples:
+            summary_lines.append(f"  [{system_tone}->{felt}] {sub}")
+    else:
+        summary_lines.append("Tone accuracy: no tone-rated entries (need system_tone + tone_override)")
     if tag_counts:
         summary_lines.append("")
         summary_lines.append(f"### Quality tags: {dict(tag_counts.most_common())}")
+    if prompt_generated_count:
+        summary_lines.append("")
+        summary_lines.append(f"### Prompt generated: {prompt_generated_count}")
     summary_text = "\n".join(summary_lines)
 
     click.echo(f"\n{summary_text}\n")

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -12,6 +12,7 @@ import random
 import sqlite3
 import sys
 import tempfile
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import patch
 
@@ -388,6 +389,142 @@ def test_handle_rate_accepts_quality_tags():
     print("  PASS: handle_rate_accepts_quality_tags")
 
 
+def test_rating_table_entity_serializes_tags_and_identity():
+    """Table Storage entity shape is stable for deployed rating sync."""
+    from subtitle_generator.rating_storage import build_rating_entity
+
+    entity = build_rating_entity(
+        "A, B, and the C of D",
+        1,
+        "pop",
+        "great",
+        "mainstream",
+        ["interesting", "funny"],
+        source="web_user",
+        prompt_generated=True,
+        now=datetime(2026, 5, 5, 4, 46, 31, tzinfo=timezone.utc),
+        row_key_suffix="abcdef12",
+    )
+
+    assert entity["PartitionKey"] == "2026-05"
+    assert entity["RowKey"] == "2026-05-05T04:46:31+00:00-abcdef12"
+    assert entity["subtitle"] == "A, B, and the C of D"
+    assert entity["thumbs"] == 1
+    assert entity["tone_override"] == "pop"
+    assert entity["free_text"] == "great"
+    assert entity["system_tone"] == "mainstream"
+    assert entity["source"] == "web_user"
+    assert entity["prompt_generated"] is True
+    assert json.loads(entity["tags"]) == ["interesting", "funny"]
+
+    tag_only_entity = build_rating_entity(
+        "A, B, and the C of D",
+        None,
+        None,
+        None,
+        None,
+        ["interesting"],
+        now=datetime(2026, 5, 5, 4, 46, 31, tzinfo=timezone.utc),
+        row_key_suffix="abcdef13",
+    )
+    assert "thumbs" not in tag_only_entity
+    assert tag_only_entity["tone_override"] == ""
+    assert tag_only_entity["free_text"] == ""
+    assert tag_only_entity["system_tone"] == ""
+    assert tag_only_entity["prompt_generated"] is False
+
+
+def test_validate_rating_body_does_not_touch_sqlite():
+    """Azure can validate tag-only ratings before any local SQLite write."""
+    from subtitle_generator.handlers import validate_rating_body
+
+    status, body, payload = validate_rating_body({
+        "subtitle": "A, B, and the C of D",
+        "system_tone": "mainstream",
+        "tags": ["interesting", "broken"],
+        "prompt_generated": True,
+    })
+
+    assert status == 200, body
+    assert payload is not None
+    assert payload.subtitle == "A, B, and the C of D"
+    assert payload.thumbs is None
+    assert payload.system_tone == "mainstream"
+    assert payload.tags == ["interesting", "broken syntax"]
+    assert payload.source == "web_user"
+    assert payload.prompt_generated is True
+
+    status, body, payload = validate_rating_body({
+        "subtitle": "A, B, and the C of D",
+        "tags": ["grammar"],
+    })
+    assert status == 400
+    assert "Invalid tags" in body["error"]
+    assert payload is None
+
+
+def test_sync_rating_entities_filters_stale_and_malformed_tags():
+    """pull-ratings keeps only current tag subsets and reports skip reasons."""
+    from subtitle_generator.cli import _sync_rating_entities
+
+    conn = make_test_db()
+    entities = [
+        {
+            "RowKey": "2026-05-05T04:46:31+00:00-valid",
+            "subtitle": "Valid, Tags, and the Sync of Ratings",
+            "thumbs": 1,
+            "tags": json.dumps(["interesting", "broken"]),
+        },
+        {
+            "RowKey": "2026-05-05T04:46:32+00:00-empty",
+            "subtitle": "Empty, Tags, and the Validity of Subsets",
+            "thumbs": -1,
+            "tags": json.dumps([]),
+            "prompt_generated": True,
+        },
+        {
+            "RowKey": "2026-05-05T04:46:33+00:00-stale",
+            "subtitle": "Stale, Tags, and the Filtering of Rows",
+            "thumbs": 1,
+            "tags": json.dumps(["interesting", "grammar"]),
+        },
+        {
+            "RowKey": "2026-05-05T04:46:34+00:00-malformed",
+            "subtitle": "Malformed, Tags, and the Skipping of Rows",
+            "thumbs": 1,
+            "tags": json.dumps({"tag": "interesting"}),
+        },
+        {
+            "RowKey": "2026-05-05T04:46:31+00:00-valid",
+            "subtitle": "Duplicate, Tags, and the Skipping of Rows",
+            "thumbs": 1,
+            "tags": json.dumps(["interesting"]),
+        },
+    ]
+
+    stats = _sync_rating_entities(conn, entities)
+    rows = conn.execute(
+        "SELECT subtitle, thumbs, tags, source, config_snapshot, prompt_generated FROM human_ratings ORDER BY id"
+    ).fetchall()
+
+    assert stats.synced == 2
+    assert stats.duplicate == 1
+    assert stats.filtered == 1
+    assert stats.malformed == 1
+    assert [row[0] for row in rows] == [
+        "Valid, Tags, and the Sync of Ratings",
+        "Empty, Tags, and the Validity of Subsets",
+    ]
+    assert [json.loads(row[2]) for row in rows] == [["interesting", "broken syntax"], []]
+    assert {row[3] for row in rows} == {"pull_ratings"}
+    assert [json.loads(row[4])["RowKey"] for row in rows] == [
+        "2026-05-05T04:46:31+00:00-valid",
+        "2026-05-05T04:46:32+00:00-empty",
+    ]
+    assert [row[5] for row in rows] == [0, 1]
+    conn.close()
+
+
 def test_empty_summary():
     """get_summary() returns None when no ratings exist."""
     from subtitle_generator.feedback import ensure_ratings_table, get_summary
@@ -413,6 +550,9 @@ if __name__ == "__main__":
         ("cli_review_mock", test_cli_review_mock),
         ("idempotent_table_creation", test_idempotent_table_creation),
         ("handle_rate_accepts_quality_tags", test_handle_rate_accepts_quality_tags),
+        ("rating_table_entity_serializes_tags_and_identity", test_rating_table_entity_serializes_tags_and_identity),
+        ("validate_rating_body_does_not_touch_sqlite", test_validate_rating_body_does_not_touch_sqlite),
+        ("sync_rating_entities_filters_stale_and_malformed_tags", test_sync_rating_entities_filters_stale_and_malformed_tags),
         ("empty_summary", test_empty_summary),
     ]
 

--- a/tests/test_pipeline_characterization.py
+++ b/tests/test_pipeline_characterization.py
@@ -190,7 +190,7 @@ def test_observed_pipeline_schema_columns(tmp_path):
     assert _columns(conn, "human_ratings") >= {
         "id", "subtitle", "system_tone", "thumbs", "tone_override",
         "free_text", "interpreted", "config_snapshot", "created_at",
-        "tags", "source",
+        "tags", "source", "prompt_generated",
     }
     assert validate_schema(conn) == []
 
@@ -1141,6 +1141,7 @@ def test_handle_rate_contract_persists_rating(tmp_path, monkeypatch):
         "thumbs": 1,
         "tone_override": "pop",
         "tags": ["interesting"],
+        "prompt_generated": True,
         "_source": "contract-test",
     })
 
@@ -1148,10 +1149,10 @@ def test_handle_rate_contract_persists_rating(tmp_path, monkeypatch):
     assert body == {"id": 1, "status": "saved"}
     conn = sqlite3.connect(db_path)
     row = conn.execute(
-        "SELECT thumbs, tone_override, tags, source FROM human_ratings"
+        "SELECT thumbs, tone_override, tags, source, prompt_generated FROM human_ratings"
     ).fetchone()
     conn.close()
-    assert row == (1, "pop", '["interesting"]', "contract-test")
+    assert row == (1, "pop", '["interesting"]', "contract-test", 1)
 
 
 def test_jacket_generation_uses_prepared_prompt_once(monkeypatch):
@@ -1260,6 +1261,37 @@ def test_rating_config_snapshot_preserves_defaults_and_overrides():
     assert snapshot["weighted_sample_spread"] == 0.12
     assert json.loads(row[1]) == ["interesting", "realistic"]
     assert row[2] == "characterization"
+
+
+def test_review_ratings_reports_prompt_only_feedback(capsys, monkeypatch):
+    from subtitle_generator import tune
+    from subtitle_generator.feedback import store_rating
+
+    conn = make_runtime_db()
+    store_rating(
+        conn,
+        "Power, Race, and the Pursuit of Happiness",
+        system_tone="mainstream",
+        tags=["interesting"],
+        source="web_user",
+        prompt_generated=True,
+    )
+
+    captured = {}
+
+    def fake_structured_completion(*args, **kwargs):
+        captured["prompt"] = kwargs["messages"][0]["content"]
+        return SimpleNamespace(diff="--- old\n+++ new\n", reasoning="prompt interest only")
+
+    monkeypatch.setattr(tune, "_load_goals", lambda: "goals")
+    monkeypatch.setattr(tune, "structured_completion", fake_structured_completion)
+
+    tune.review_ratings(conn, source="web_user", model="fake-model")
+
+    output = capsys.readouterr().out
+    assert "Prompt generated: 1" in output
+    assert "Tone accuracy: no tone-rated entries" in output
+    assert "Prompt generated: 1" in captured["prompt"]
 
 
 def test_tuning_config_change_applies_and_reverts_rows():

--- a/uv.lock
+++ b/uv.lock
@@ -159,6 +159,22 @@ wheels = [
 ]
 
 [[package]]
+name = "azure-identity"
+version = "1.25.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "cryptography" },
+    { name = "msal" },
+    { name = "msal-extensions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/0e/3a63efb48aa4a5ae2cfca61ee152fbcb668092134d3eb8bfda472dd5c617/azure_identity-1.25.3.tar.gz", hash = "sha256:ab23c0d63015f50b630ef6c6cf395e7262f439ce06e5d07a64e874c724f8d9e6", size = 286304, upload-time = "2026-03-13T01:12:20.892Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/9a/417b3a533e01953a7c618884df2cb05a71e7b68bdbce4fbdb62349d2a2e8/azure_identity-1.25.3-py3-none-any.whl", hash = "sha256:f4d0b956a8146f30333e071374171f3cfa7bdb8073adb8c3814b65567aa7447c", size = 192138, upload-time = "2026-03-13T01:12:22.951Z" },
+]
+
+[[package]]
 name = "blis"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -199,6 +215,51 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
 ]
 
 [[package]]
@@ -295,6 +356,59 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ca/65/efd0fe8a936fc8ca2978cb7b82581fb20d901c6039e746a808f746b7647b/confection-1.3.3.tar.gz", hash = "sha256:f0f6810d567ff73993fe74d218ca5e1ffb6a44fb03f391257fc5d033546cbfaa", size = 54895, upload-time = "2026-03-24T18:45:24.331Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/e4/d66708bdf0d92fb4d49b22cdff4b10cec38aca5dcd7e81d909bb55c65cd7/confection-1.3.3-py3-none-any.whl", hash = "sha256:b9fef9ee84b237ef4611ec3eb5797b70e13063e6310ad9f15536373f5e313c82", size = 35902, upload-time = "2026-03-24T18:45:22.664Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "48.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
+    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
+    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
 ]
 
 [[package]]
@@ -877,6 +991,32 @@ wheels = [
 ]
 
 [[package]]
+name = "msal"
+version = "1.36.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/cb/b02b0f748ac668922364ccb3c3bff5b71628a05f5adfec2ba2a5c3031483/msal-1.36.0.tar.gz", hash = "sha256:3f6a4af2b036b476a4215111c4297b4e6e236ed186cd804faefba23e4990978b", size = 174217, upload-time = "2026-04-09T10:20:33.525Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/d3/414d1f0a5f6f4fe5313c2b002c54e78a3332970feb3f5fed14237aa17064/msal-1.36.0-py3-none-any.whl", hash = "sha256:36ecac30e2ff4322d956029aabce3c82301c29f0acb1ad89b94edcabb0e58ec4", size = 121547, upload-time = "2026-04-09T10:20:32.336Z" },
+]
+
+[[package]]
+name = "msal-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/99/5d239b6156eddf761a636bded1118414d161bd6b7b37a9335549ed159396/msal_extensions-1.3.1.tar.gz", hash = "sha256:c5b0fd10f65ef62b5f1d62f4251d51cbcaf003fcedae8c91b040a488614be1a4", size = 23315, upload-time = "2025-03-14T23:51:03.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/75/bd9b7bb966668920f06b200e84454c8f3566b102183bc55c5473d96cb2b9/msal_extensions-1.3.1-py3-none-any.whl", hash = "sha256:96d3de4d034504e969ac5e85bae8106c8373b5c6568e4c8fa7af2eca9dbe6bca", size = 20583, upload-time = "2025-03-14T23:51:03.016Z" },
+]
+
+[[package]]
 name = "multidict"
 version = "6.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1209,6 +1349,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1295,6 +1444,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -1721,7 +1884,7 @@ wheels = [
 
 [[package]]
 name = "subtitle-generator"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -1737,6 +1900,7 @@ dependencies = [
 [package.optional-dependencies]
 deploy = [
     { name = "azure-data-tables" },
+    { name = "azure-identity" },
 ]
 e2e = [
     { name = "playwright" },
@@ -1756,6 +1920,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "azure-data-tables", marker = "extra == 'deploy'", specifier = ">=12.5" },
+    { name = "azure-identity", marker = "extra == 'deploy'", specifier = ">=1.25" },
     { name = "click", specifier = ">=8.3.2" },
     { name = "en-core-web-md", url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.8.0/en_core_web_md-3.8.0-py3-none-any.whl" },
     { name = "en-core-web-sm", url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl" },

--- a/web/index.html
+++ b/web/index.html
@@ -219,7 +219,7 @@ body{font-family:'Segoe UI',system-ui,sans-serif;background:#1a1a2e;color:#e0e0e
       <button class="btn-tag" :class="{ active: selectedTags.includes('realistic') }" @click="toggleTag('realistic')" data-testid="tag-realistic">✅ Realistic</button>
       <button class="btn-tag" :class="{ active: selectedTags.includes('funny') }" @click="toggleTag('funny')">😂 Funny</button>
       <button class="btn-tag" :class="{ active: selectedTags.includes('boring') }" @click="toggleTag('boring')">🥱 Boring</button>
-      <button class="btn-tag" :class="{ active: selectedTags.includes('broken') }" @click="toggleTag('broken')">🪦 Broken</button>
+      <button class="btn-tag" :class="{ active: selectedTags.includes('broken syntax') }" @click="toggleTag('broken syntax')">🪦 Broken syntax</button>
       <button class="btn-tag" :class="{ active: selectedTags.includes('nonsense') }" @click="toggleTag('nonsense')">🥴 Nonsense</button>
     </div>
   </div>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -50,6 +50,7 @@ export function createApp() {
     jacketMd: "",
     prompt: null,
     toneTier: null,
+    promptGenerated: false,
 
     // ── Init ──
     async init() {
@@ -102,6 +103,7 @@ export function createApp() {
       this.loading = true;
       this._setJacket(null);
       this.prompt = null;
+      this.promptGenerated = false;
 
       const result = await api.generate({
         tone: this.tone || null,
@@ -129,23 +131,25 @@ export function createApp() {
     },
 
     async _flushRating() {
-      if (!this.hasSubtitle || this.selectedTags.length === 0) return;
+      if (!this.hasSubtitle || (this.selectedTags.length === 0 && !this.promptGenerated)) return;
       try {
         await api.rate({
           subtitle: this.subtitle.fullText,
           system_tone: this.tone || null,
           tags: this.selectedTags.slice(),
+          prompt_generated: this.promptGenerated,
         });
       } catch (e) { /* best-effort; don't block generate */ }
     },
 
     _flushRatingBeacon() {
-      if (!this.hasSubtitle || this.selectedTags.length === 0) return;
+      if (!this.hasSubtitle || (this.selectedTags.length === 0 && !this.promptGenerated)) return;
       try {
         const body = JSON.stringify({
           subtitle: this.subtitle.fullText,
           system_tone: this.tone || null,
           tags: this.selectedTags.slice(),
+          prompt_generated: this.promptGenerated,
         });
         const blob = new Blob([body], { type: "application/json" });
         navigator.sendBeacon(apiBase + "/api/rate", blob);
@@ -178,6 +182,7 @@ export function createApp() {
         } else {
           this.prompt = result.prompt;
           this.toneTier = result.tone_tier;
+          this.promptGenerated = true;
           this._setJacket(result.result);
         }
         this.jacketLoading = false;
@@ -227,6 +232,7 @@ export function createApp() {
             const parsed = JSON.parse(data);
             this.prompt = parsed.prompt;
             this.toneTier = parsed.tone_tier;
+            this.promptGenerated = true;
             this._setJacket(parsed.result);
             receivedTerminalEvent = true;
           } else if (eventType === "error") {

--- a/web/js/services.js
+++ b/web/js/services.js
@@ -87,9 +87,9 @@ export function createApi(baseUrl = "", fetchFn = fetch) {
     },
 
     /** Submit a human rating for a subtitle. */
-    async rate({ subtitle, thumbs, tone_override, system_tone, free_text, tags } = {}) {
-      const result = await post("/api/rate", { subtitle, thumbs, tone_override, system_tone, free_text, tags });
-      trackEvent("RateSubtitle", { thumbs: String(thumbs), tone_override: tone_override || "none", tags: (tags || []).join(",") });
+    async rate({ subtitle, thumbs, tone_override, system_tone, free_text, tags, prompt_generated } = {}) {
+      const result = await post("/api/rate", { subtitle, thumbs, tone_override, system_tone, free_text, tags, prompt_generated });
+      trackEvent("RateSubtitle", { thumbs: String(thumbs), tone_override: tone_override || "none", tags: (tags || []).join(","), prompt_generated: String(!!prompt_generated) });
       return result;
     },
   };

--- a/web/js/spot-check-app.js
+++ b/web/js/spot-check-app.js
@@ -221,7 +221,7 @@ export function spotCheckApp() {
       } else if (this.phase === "reveal") {
         if (key === "f") { this.toggleTag("funny"); event.preventDefault(); }
         else if (key === "b") { this.toggleTag("boring"); event.preventDefault(); }
-        else if (key === "r") { this.toggleTag("broken"); event.preventDefault(); }
+        else if (key === "r") { this.toggleTag("broken syntax"); event.preventDefault(); }
         else if (key === "n") { this.toggleTag("nonsense"); event.preventDefault(); }
         else if (key === "l") { this.toggleTag("realistic"); event.preventDefault(); }
         else if (key === "i") { this.toggleTag("interesting"); event.preventDefault(); }

--- a/web/spot-check.html
+++ b/web/spot-check.html
@@ -227,7 +227,7 @@ body{font-family:'Segoe UI',system-ui,sans-serif;background:#1a1a2e;color:#e0e0e
             <button class="btn-tag" :class="{ active: currentTags.includes('realistic') }" @click="toggleTag('realistic')" data-testid="tag-realistic">✅ Realistic <kbd>L</kbd></button>
             <button class="btn-tag" :class="{ active: currentTags.includes('funny') }" @click="toggleTag('funny')" data-testid="tag-funny">😂 Funny <kbd>F</kbd></button>
             <button class="btn-tag" :class="{ active: currentTags.includes('boring') }" @click="toggleTag('boring')" data-testid="tag-boring">🥱 Boring <kbd>B</kbd></button>
-            <button class="btn-tag" :class="{ active: currentTags.includes('broken') }" @click="toggleTag('broken')" data-testid="tag-broken">🪦 Broken <kbd>R</kbd></button>
+            <button class="btn-tag" :class="{ active: currentTags.includes('broken syntax') }" @click="toggleTag('broken syntax')" data-testid="tag-broken-syntax">🪦 Broken syntax <kbd>R</kbd></button>
             <button class="btn-tag" :class="{ active: currentTags.includes('nonsense') }" @click="toggleTag('nonsense')" data-testid="tag-nonsense">🥴 Nonsense <kbd>N</kbd></button>
           </div>
         </div>


### PR DESCRIPTION
## Summary

| Area | Change |
|---|---|
| Azure Function | `/api/rate` now validates ratings and writes directly to Azure Table Storage in `SUBTITLE_GEN_MODE=azure`, without depending on packaged SQLite. |
| Durable storage | Added shared `rating_storage` helper with `create_table_if_not_exists`, non-null Table entity serialization, and required-vs-best-effort failure semantics. |
| Sync | `pull-ratings` now skips malformed rows, filters stale tag sets, normalizes legacy `broken` to canonical `broken syntax`, dedupes by RowKey, and syncs `prompt_generated`. |
| Feedback model | Added `prompt_generated` as a strong interest signal in `human_ratings`, summaries, and `review-ratings`. |
| Infra/deps | Provisions the `ratings` table, grants Storage Table Data Contributor RBAC, and adds Azure identity/table dependencies. |
| UI/docs/tests | Renamed the tag to `broken syntax`, sends prompt-generation feedback, updates docs, and adds regression coverage. |

## Breaking changes

None expected for clients. Existing remote `broken` tags are accepted and normalized to `broken syntax` during validation/import.

## Validation

- `uv run pytest`
- `uv run ruff check src\\subtitle_generator api tests`
- `uv run ty check`
- `pwsh -File scripts\\run-local-e2e.ps1`
- Multi-model review: Opus 4.7 and GPT-5.5; all findings addressed.