### PR TITLE
fix: lazy load feedback pydantic schema

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "subtitle-generator"
-version = "0.6.1"
+version = "0.6.2"
 description = "Generate bizarre book subtitles by mixing real parts from Library of Congress MARC records"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/subtitle_generator/__init__.py
+++ b/src/subtitle_generator/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("subtitle-generator")
 except PackageNotFoundError:
-    __version__ = "0.6.1"
+    __version__ = "0.6.2"

--- a/src/subtitle_generator/feedback.py
+++ b/src/subtitle_generator/feedback.py
@@ -13,8 +13,6 @@ import sqlite3
 from collections import Counter
 from typing import Any
 
-from pydantic import BaseModel
-
 from subtitle_generator.config import load_tuning_config
 
 VALID_RATING_TAGS = frozenset({
@@ -55,19 +53,6 @@ def parse_rating_tags(value: Any) -> list[str]:
 def rating_tags_are_current(tags: list[str]) -> bool:
     """Return true when a rating's tags are all current supported options."""
     return not (set(tags) - VALID_RATING_TAGS)
-
-# ---------------------------------------------------------------------------
-# Pydantic schemas
-# ---------------------------------------------------------------------------
-
-
-class HumanFeedbackInterp(BaseModel):
-    """LLM-interpreted structure from a free-text human comment."""
-
-    sentiment: str  # positive / negative / neutral
-    tone_signal: str | None  # too-pop / too-niche / good-tone / None
-    actionable_insight: str  # one-sentence summary for the proposer
-
 
 # ---------------------------------------------------------------------------
 # DB setup
@@ -176,9 +161,18 @@ Classify this comment:
 """
 
 
-def interpret_free_text(comment: str) -> HumanFeedbackInterp:
+def interpret_free_text(comment: str):
     """Use a cheap LLM call to interpret free-text feedback."""
+    from pydantic import BaseModel
+
     from subtitle_generator.eval_harness import structured_completion
+
+    class HumanFeedbackInterp(BaseModel):
+        """LLM-interpreted structure from a free-text human comment."""
+
+        sentiment: str  # positive / negative / neutral
+        tone_signal: str | None  # too-pop / too-niche / good-tone / None
+        actionable_insight: str  # one-sentence summary for the proposer
 
     return structured_completion(
         model="github_copilot/gpt-5.4-mini",

--- a/uv.lock
+++ b/uv.lock
@@ -1884,7 +1884,7 @@ wheels = [
 
 [[package]]
 name = "subtitle-generator"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

| Area | Change |
|---|---|
| Azure Function runtime | Stops importing `pydantic` on the normal `/api/rate` path by moving the free-text interpretation schema inside `interpret_free_text()`. |
| Version | Bumps package version to `0.6.2` for the hotfix PR. |

## Why

The deployed rating endpoint failed with `Internal error: No module named 'pydantic'` because `feedback.py` imported the optional free-text schema at module import time. Tag-only web ratings do not need free-text interpretation or pydantic.

## Validation

- `uv run pytest`
- `uv run ruff check src\\subtitle_generator api tests`
- `uv run ty check`
- Two-model review: Opus 4.7 and GPT-5.5; no issues found.