### PR TITLE
test: match deployed API generate URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "subtitle-generator"
-version = "0.11.0"
+version = "0.11.1"
 description = "Generate bizarre book subtitles by mixing real parts from Library of Congress MARC records"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/subtitle_generator/__init__.py
+++ b/src/subtitle_generator/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("subtitle-generator")
 except PackageNotFoundError:
-    __version__ = "0.11.0"
+    __version__ = "0.11.1"

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -220,7 +220,7 @@ async def test_footer_remix_and_mobile(page: Page) -> None:
 
     print("TEST 10: Remix rendering")
     await page.locator("select").first.select_option("")
-    remix_route = "**/api/generate"
+    remix_route = "**/api/generate**"
 
     async def fulfill_remix(route) -> None:
         await route.fulfill(

--- a/uv.lock
+++ b/uv.lock
@@ -2118,7 +2118,7 @@ wheels = [
 
 [[package]]
 name = "subtitle-generator"
-version = "0.11.0"
+version = "0.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

| Area | Change |
|---|---|
| Deployed e2e | Match `/api/generate` routes with suffixes/query strings so the remix rendering mock applies on the deployed API URL. |
| Version | Bumped package version to `0.11.1`. |

## Validation

- `uv run ruff check`
- `uv run ty check`
- `uv run pytest -q`
- `pwsh -File scripts\\run-local-e2e.ps1`

## Breaking changes

None.