### PR TITLE
docs: clarify pipeline e2e model weights

### DIFF
--- a/docs/pipeline-end-to-end.md
+++ b/docs/pipeline-end-to-end.md
@@ -1,3 +1,5 @@
+> Created/edited by GitHub Copilot with human review/feedback by Avi Levin.
+
 # End-to-end pipeline walkthrough
 
 This document explains the pipeline in the order you would run it from a clean
@@ -38,7 +40,7 @@ generator weights existing strict fillers for a requested tier.
 | Remix | Recombining parts of a multi-word `of_object` to make a new final object while staying close to real source phrasing. |
 | Runtime config | Rows in the DB `config` table that tune generation behavior and are exported to `api\data\config.csv`. |
 | Teacher model | The rich offline Torch model trained with the broadest feature set. |
-| Student model | The exportable Torch model trained to imitate the teacher using durable/export-safe features. |
+| Student model | The exportable Torch model trained to imitate the teacher using durable/export-safe features. After rollup, the selected student's probabilities are the runtime weights in `slot_filler_model_scores`; there is no separate hidden runtime model. |
 | Rollup | Aggregation from book-level predictions back onto filler-level scores. |
 
 ## 0. Runtime contract
@@ -55,12 +57,24 @@ The deployed generator has four responsibilities:
 When model scores are present, requested tier `T` uses:
 
 ```text
-weight = sqrt(freq) * score_T
+weight = sqrt(freq) * max(score_T, 0.001)
 ```
+
+In math notation, for filler `f` and requested tier `T`:
+
+$$
+w(f, T) = \sqrt{\operatorname{freq}(f)} \cdot \max(s_T(f), 0.001)
+$$
+
+If a local row has no usable model score, generation falls back to
+`sqrt(freq)`.
 
 Deployment is expected to include complete `slot_filler_model_scores.csv`
 coverage. If a local DB has no score table, generation can still sample by
-frequency, but requested-tier behavior depends on learned scores.
+frequency, but requested-tier behavior depends on learned scores. Weight-wise,
+the deployed generator consumes the selected student rollup directly:
+`score_pop`, `score_mainstream`, and `score_niche` become the per-filler tier
+weights used by runtime sampling and tier evidence.
 
 The guardrail is intentionally narrow. It rejects literal artifacts such as bare
 adjective-shaped final objects (`Christian`), typo/acronym artifacts (`Imf`),
@@ -151,8 +165,71 @@ The key filler fields are:
 | `popularity_level` | Coarse availability of source popularity evidence. |
 | `popularity_confidence` | Confidence in the popularity score. |
 
+The source-specific values are first normalized onto comparable percentile-like
+scales. For most sources, the normalized value is the percentile rank of
+`log10(1 + raw_count)` among works with that source. NYT uses a high-intent
+bestseller signal instead:
+
+```text
+nyt_score = min(1.0, 0.8 + 0.2 * log10(1 + weeks_on_list) / 2.0)
+```
+
+The deployed popularity scalar is a weighted average over available source
+signals divided by the total configured source weight. Missing source signals
+contribute zero by being absent from the numerator. Open Library is one of the
+source signals; it is not a separate runtime backoff term.
+
+$$
+\begin{aligned}
+\operatorname{pop}(w) &=
+  \frac{\sum_{i \in P(w)} \alpha_i x_i(w)}
+       {\sum_{j \in A} \alpha_j} \\
+\operatorname{pop}(f) &=
+  \operatorname{mean}\left(
+    \operatorname{top3}\{\operatorname{pop}(w): w \rightarrow f\}
+  \right)
+\end{aligned}
+$$
+
+Here `w` is a source work, `f` is a filler, `P(w)` is the set of available
+source signals for that work, `A` is the full configured source set, `x_i` is
+the normalized source signal, and `alpha_i` is the configured source weight. The
+implementation-shaped version is:
+
+```text
+work_popularity_score =
+  sum(source_weight_i * normalized_source_i for present sources)
+  / sum(all configured source weights)
+
+filler_popularity_score =
+  mean(top 3 source-book work_popularity_score values linked to the filler)
+```
+
+Fillers without Level 1 source/work popularity data use a frequency fallback:
+
+```text
+filler_popularity_score = log10(1 + freq)
+popularity_level = 0
+popularity_confidence = 0.0
+```
+
+The `pop_weight_*` rows in `config` are source weights for this scalar, not tier
+weights. They answer "how much should this data source count when computing
+source/filler popularity?" The current exported source weights are:
+
+| Config key | Source signal | Current value | Meaning |
+|---|---|---:|---|
+| `pop_weight_spl` | Seattle Public Library checkouts per year | 0.50157190 | Direct circulation demand. |
+| `pop_weight_ol` | Open Library edition count | 0.61780976 | Breadth/availability signal. |
+| `pop_weight_gr` | Goodreads rating count | 0.12437461 | Reader engagement demand. |
+| `pop_weight_library` | Other library/list appearances | 0.02924338 | Additional library demand or holdings evidence. |
+| `pop_weight_nyt` | NYT bestseller weeks | 0.02978305 | High-intent bestseller evidence. |
+| `pop_weight_trove` | Trove library count | 0.14721717 | Australian library breadth. |
+
 Popularity matters because it gives the models demand evidence, but it is too
-blunt to distinguish all pop/mainstream/niche behavior by itself.
+blunt to distinguish all pop/mainstream/niche behavior by itself. A popular
+source can still provide a niche-shaped filler, and a niche source can still
+provide a broadly accessible phrase.
 
 ## 4. Precompute runtime-safe remix features
 
@@ -185,12 +262,19 @@ Examples:
 Generation can then compose candidate parts and reject low-similarity remixes
 without spaCy or full vector state.
 
-## 5. Check runtime config at the boundary it affects
+## 5. Runtime config reference
 
 Runtime constants live in the full DB `config` table, then get exported to
 `api\data\config.csv` and packaged into the mini DB. In a normal rerun, these
 rows may already exist; you do not rerun every tuner just because you are
 retraining the book model.
+
+Config has two kinds of rows:
+
+| Kind | Examples | How runtime reads it |
+|---|---|---|
+| Tunable numeric parameters | `generation_tier_ratio_*`, `pop_weight_*`, `tier_classifier_*`, `article_*` | Loaded through `load_tuning_config()`, with defaults from `config.py` if a DB row is absent. Default-only rows may not appear in checked-in `api\data\config.csv`. |
+| Generated runtime state | `article_stats_*`, `centroid_norm`, `avg_cross_sim_*`, `remix_calibrated_*` | Read directly from the exported DB by generation/remix code. Missing remix calibration rows fall back to baked-in CLI/API defaults (`0.8` remix probability and `0.1` minimum similarity). |
 
 The timing depends on what the constant feeds:
 
@@ -201,6 +285,31 @@ The timing depends on what the constant feeds:
 | `article_of_min_freq`, `article_action_min_freq`, `article_remix_heuristic_threshold` | After generation can produce realistic samples | final sample checks and `export-data` | These are generation heuristics; changing them does not retrain weights unless you use generated samples as review evidence. |
 | `generation_tier_ratio_pop/mainstream/niche` | Before final runtime validation/export | `export-data`, `build-db` | These control the default tier mix when no explicit tone is requested. |
 | `pop_missing_default` | Before `calibrate-runtime-tier-model` if missing popularity should change classifier feature defaults | runtime tier calibration, export if changed | Used only as the sparse-popularity default inside the learned runtime classifier. |
+
+### Config key reference
+
+| Key or key family | Used by | Formula or behavior |
+|---|---|---|
+| `generation_tier_ratio_pop`, `generation_tier_ratio_mainstream`, `generation_tier_ratio_niche` | Default generation when no explicit model tier is requested | Negative values are clamped to zero, then normalized: `P(tier) = max(0, ratio_tier) / sum(max(0, ratio_*))`. If the sum is zero, runtime falls back to mainstream. Defaults are `0.0183`, `0.1172`, and `0.8645`. |
+| `pop_weight_spl`, `pop_weight_ol`, `pop_weight_gr`, `pop_weight_library`, `pop_weight_nyt`, `pop_weight_trove` | Popularity enrichment and popularity-weight calibration | Source weights for the collapsed popularity scalar. The weights are learned by `calibrate-runtime-tier-model`/popularity calibration and then used when recomputing `slot_fillers.popularity_score`. |
+| `pop_weight_freq` | Legacy/tuning surface | Present in the tunable config contract, but current popularity recomputation does not include it in the source-weighted scalar. Default is `0.0`. |
+| `pop_exponent` | Legacy/tuning surface and parameter export | Accepted by the popularity population CLI and carried in the parameter state contract, but the current percentile-based scoring path does not raise scores by this exponent. Default is `1.2`. |
+| `pop_missing_default` | Runtime tier classifier | Substitute popularity value when a scored slot lacks `popularity_score`. Default is `0.1`. |
+| `tier_classifier_model_score_weight` | Runtime tier classifier | Multiplier on the averaged student/rollup model score for every tier. Current exported value is `1.66202044`, so the runtime classifier leans more strongly on the student score than the default mean-of-slots behavior. |
+| `tier_classifier_slot_weight_list_item`, `tier_classifier_slot_weight_action_noun`, `tier_classifier_slot_weight_of_object` | Runtime tier classifier | Per-slot averaging weights. Current values are all `1`, so list items, action noun, and final object contribute equally. |
+| `tier_classifier_intercept_pop/mainstream/niche` | Runtime tier classifier | Per-tier bias added before softmax. Current values are `-0.17850681`, `-0.12991610`, and `0.23270014`. |
+| `tier_classifier_popularity_weight_pop/mainstream/niche` | Runtime tier classifier | Per-tier additive popularity coefficient. It answers "does raw slot popularity push this assembled subtitle toward this tier?" Current values are `-0.03210073`, `0.03258492`, and `0.00859780`. |
+| `tier_classifier_popularity_interaction_pop/mainstream/niche` | Runtime tier classifier | Per-tier coefficient on `popularity * student_score_for_tier`. It answers "does popularity amplify the student's evidence for this tier?" Current values are `0.18485981`, `0.00266052`, and `0.26849598`. |
+| `tier_classifier_frequency_weight_pop/mainstream/niche` | Runtime tier classifier | Per-tier coefficient on average slot frequency score. Current values are `-0.10489431`, `0.14781234`, and `-0.00470662`. |
+| `tier_classifier_temperature` | Runtime tier classifier | Softmax temperature for calibrated logits. Current value is `1.0`. |
+| `article_of_min_freq` | Article choice for final objects | Minimum corpus count before a majority article can be trusted for an `of_object`. Default is `1.0`. |
+| `article_action_min_freq` | Article choice for action nouns | Minimum corpus count before a majority article can be trusted for an action noun. Default is `1.0`. |
+| `article_remix_heuristic_threshold` | Article choice for remixed final objects | Minimum majority fraction for an exact/remix-head article decision. Default is `0.6`. |
+| `remix_reject_double_of` | Remix guardrail | Tunable boolean-like guardrail for rejecting awkward double-`of` constructions. Default is `1.0`. |
+| `article_stats_action_noun`, `article_stats_of_object` | Article choice | JSON maps from lowercased fillers or head words to observed article counts. Runtime chooses the majority article only when counts clear the relevant frequency/threshold gate. |
+| `centroid_norm`, `avg_cross_sim_t1`, `avg_cross_sim_t2` | Remix coherence check | Scalar approximation constants for remix cosine similarity: `similarity = total_dot / (sqrt(sum(norm_sq) + cross_correction) * centroid_norm)`, where `cross_correction` uses the type-specific `avg_cross_sim_*`. |
+| `remix_calibrated_min_sim` | Remix acceptance | Minimum approximate similarity for accepting a remixed `of_object`. Written by `calibrate-remix`; CLI/API default to `0.1` if the row is absent. |
+| `remix_calibrated_remix_prob` | Remix sampling | Default probability of attempting a remix in CLI/API surfaces. Written by `calibrate-remix`; CLI/API default to `0.8` if the row is absent. |
 
 Useful commands:
 
@@ -393,6 +502,20 @@ toward a broader pop/mainstream pool. That is desirable for generation because
 the deployed scores are sampling weights over strict fillers, not final claims
 about a book's market category.
 
+The student is "runtime-equivalent" weight-wise after rollup. The Torch file
+itself is not loaded by the deployed CLI/API, but its output probabilities are
+rolled onto fillers and installed as `slot_filler_model_scores`. Runtime then
+uses those installed probabilities directly:
+
+```text
+student book probabilities
+  -> average probabilities over source books linked to each strict filler
+  -> slot_filler_model_scores.score_pop/mainstream/niche
+  -> generation weight sqrt(freq) * max(score_for_requested_tier, 0.001)
+```
+
+So a student refresh is a runtime-weight refresh, not a separate advisory report.
+
 ## 11. Roll book predictions up to fillers
 
 ```powershell
@@ -422,6 +545,15 @@ The filler universe is unchanged; only the learned probabilities changed. This
 is why a refreshed `slot_filler_model_scores.csv` can broaden pop/mainstream
 generation without changing which text is allowed.
 
+For a filler `F` and tier `T`, the rollup is:
+
+```text
+score_T(F) =
+  average(student_score_T(book) for each source book that contributed F)
+```
+
+Those `score_T(F)` values are the deployed per-filler model weights.
+
 ## 12. Calibrate the runtime tier model
 
 After the rich teacher, exportable students, and selected shadow rollup exist,
@@ -436,15 +568,30 @@ uv run subtitle-gen calibrate-runtime-tier-model `
 
 The step fits the collapsed popularity scalar:
 
+$$
+\operatorname{popularity\_scalar}(x) =
+  \sum_i
+    \frac{\max(0, \operatorname{pop\_weight}_i)}
+         {\sum_j \max(0, \operatorname{pop\_weight}_j)}
+    x_i
+$$
+
 ```text
 popularity_scalar =
-  w_spl*SPL
-+ w_ol*OpenLibrary
-+ w_goodreads*Goodreads
-+ w_library*Library
-+ w_nyt*NYT
-+ w_trove*Trove
+  share_spl*SPL
++ share_ol*OpenLibrary
++ share_goodreads*Goodreads
++ share_library*Library
++ share_nyt*NYT
++ share_trove*Trove
+
+share_i = max(0, pop_weight_i) / sum(max(0, pop_weight_*))
 ```
+
+This constrained popularity calibration trains against the default accessibility
+target, `teacher_pop + 0.5 * teacher_mainstream`, unless run with a different
+target mode. It produces source-share weights that can be collapsed back into
+runtime `pop_weight_*` values.
 
 It then fits final assembled-subtitle classifier coefficients over the chosen
 slot model probabilities, slot popularity, popularity interactions, and
@@ -463,6 +610,66 @@ uv run subtitle-gen calibrate-runtime-tier-model `
 If `--apply` changes popularity-derived feature inputs and you want those
 refreshed inputs reflected in the exportable student, rerun `Distill` and
 `Shadow` before installing scores and exporting.
+
+The per-tier popularity weights in the DB are part of this final assembled-subtitle
+classifier, not the source-popularity scalar above. They are learned by minimizing
+MSE against the rich teacher's `score_pop`, `score_mainstream`, and `score_niche`
+for generated book-feature examples that have complete slot evidence. For each
+generated subtitle:
+
+$$
+\begin{aligned}
+z_T &= b_T +
+  \frac{\sum_{k \in S}\lambda_k\left(
+    \beta_m s_T(k) +
+    \beta_{p,T}\operatorname{pop}(k) +
+    \beta_{q,T}\operatorname{pop}(k)s_T(k) +
+    \beta_{r,T}\operatorname{freqScore}(k)
+  \right)}
+  {\sum_{k \in S}\lambda_k} \\
+\operatorname{runtimeScore}_T &=
+  \frac{\exp(z_T / \tau)}
+       {\sum_U \exp(z_U / \tau)}
+\end{aligned}
+$$
+
+Here `S` is the generated subtitle's scored slots, `lambda_k` is the configured
+slot weight for the slot type, `s_T(k)` is the selected student rollup score for
+tier `T`, and the `beta`/`b`/`tau` terms are the `tier_classifier_*` config
+values. Runtime applies the slot weight to the whole per-slot contribution, then
+divides by the total slot weight. Calibration builds equivalent unweighted
+example features because the current exported slot weights are all `1`.
+
+The implementation-shaped runtime version is:
+
+```text
+slot_contribution_T =
+  tier_classifier_model_score_weight * slot_score_T
+  + tier_classifier_popularity_weight_T * slot_popularity
+  + tier_classifier_popularity_interaction_T * slot_popularity * slot_score_T
+  + tier_classifier_frequency_weight_T * slot_frequency_score
+
+logit_T =
+  tier_classifier_intercept_T
+  + weighted_average(slot_contribution_T over generated slots)
+
+runtime_score_T = softmax(logit_T / tier_classifier_temperature)
+```
+
+That means:
+
+| Config family | What it means |
+|---|---|
+| `tier_classifier_popularity_weight_T` | Popularity's direct push toward tier `T`, regardless of the student's tier score. |
+| `tier_classifier_popularity_interaction_T` | Popularity's amplification or dampening of the student's evidence for tier `T`. |
+| `tier_classifier_frequency_weight_T` | Whether common source fillers push the assembled subtitle toward tier `T`. |
+
+The current exported tier popularity weights are small compared with the model
+score multiplier, so they adjust the selected student rollup rather than replace
+it. For example, `tier_classifier_popularity_weight_pop` is negative while
+`tier_classifier_popularity_interaction_pop` is positive: raw popularity alone
+does not automatically make a subtitle pop, but popularity can strengthen pop
+evidence when the student already sees pop-shaped slots.
 
 ## 13. Optional sample review gates
 
@@ -578,14 +785,19 @@ When complete model scores are present, generation uses the requested tier score
 as the sampling signal:
 
 ```text
-weight = sqrt(freq) * score_for_requested_tier
+weight = sqrt(freq) * max(score_for_requested_tier, 0.001)
 ```
+
+Equivalently:
+$w(f, T) = \sqrt{\operatorname{freq}(f)} \cdot \max(s_T(f), 0.001)$.
+Rows without a usable model score fall back to `sqrt(freq)`.
 
 `compute_tier_evidence()` classifies generated subtitles:
 
 | DB state | Classifier behavior |
 |---|---|
-| Complete `slot_filler_model_scores` | Average per-slot learned tier probabilities and choose the highest tier with deterministic tie-breaking. |
+| Complete `slot_filler_model_scores` plus calibrated `tier_classifier_*` config | Compute calibrated per-tier logits from student rollup scores, slot popularity, popularity interactions, and frequency, then softmax and choose the highest tier with deterministic tie-breaking. |
+| Complete `slot_filler_model_scores` with default classifier config | Average per-slot learned tier probabilities and choose the highest tier with deterministic tie-breaking. This is the fallback because defaults set model weight to `1.0` and all intercept/popularity/frequency coefficients to `0.0`. |
 | Remixed `of_object` | Classify from the structured remix components (`of_modifier` + `of_head`, or `of_topic` + `of_complement`) rather than looking for the newly composed object as a separate filler. |
 | Missing generated-slot evidence | Return neutral mainstream evidence for arbitrary/user-entered text; generated subtitles should carry scored slots or remix parts. |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "subtitle-generator"
-version = "0.11.1"
+version = "0.11.2"
 description = "Generate bizarre book subtitles by mixing real parts from Library of Congress MARC records"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/subtitle_generator/__init__.py
+++ b/src/subtitle_generator/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("subtitle-generator")
 except PackageNotFoundError:
-    __version__ = "0.11.1"
+    __version__ = "0.11.2"

--- a/uv.lock
+++ b/uv.lock
@@ -2118,7 +2118,7 @@ wheels = [
 
 [[package]]
 name = "subtitle-generator"
-version = "0.11.1"
+version = "0.11.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

| Area | Change |
|---|---|
| Pipeline documentation | Clarifies that selected student rollups become runtime filler weights. |
| Runtime formulas | Documents sampling floor, popularity scoring, tier-classifier logits, and config defaults. |
| Release metadata | Bumps package version to 0.11.2 for PR/version check compliance. |

## Validation

- `uv run pytest` — 168 passed
- `uv run ruff check` — passed
- `uv run ty check` — passed
- Multi-model review — no significant issues found

## Breaking changes

None.