### PR TITLE
fix: materialize packaged SQLite for Azure

### DIFF
--- a/src/subtitle_generator/handlers.py
+++ b/src/subtitle_generator/handlers.py
@@ -6,7 +6,10 @@ its own response type.
 """
 
 import os
+import shutil
 import sqlite3
+import tempfile
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -31,6 +34,8 @@ from subtitle_generator.shadow_runtime import build_generation_runtime
 
 TONE_CHOICES = {"pop": TONE_HIGH, "mainstream": TONE_MEDIUM, "niche": TONE_LOW}
 VALID_TONES = set(TONE_CHOICES.keys())
+_azure_db_cache: dict[tuple[str, int, int], Path] = {}
+_azure_db_cache_lock = threading.Lock()
 
 
 @dataclass(frozen=True)
@@ -60,11 +65,51 @@ def get_db(db_path: str | None = None) -> sqlite3.Connection:
     if not path.is_absolute():
         path = Path(__file__).resolve().parent.parent / path
     if os.environ.get("SUBTITLE_GEN_MODE") == "azure":
+        path = _materialize_azure_db(path)
         return sqlite3.connect(
             f"{path.resolve().as_uri()}?mode=ro&immutable=1",
             uri=True,
         )
     return sqlite3.connect(path)
+
+
+def _materialize_azure_db(
+    packaged_path: Path,
+    *,
+    temp_root: Path | None = None,
+) -> Path:
+    source = packaged_path.resolve()
+    try:
+        stat = source.stat()
+    except FileNotFoundError as exc:
+        raise RuntimeError(f"Packaged database does not exist: {source}") from exc
+    cache_key = (str(source), stat.st_mtime_ns, stat.st_size)
+    with _azure_db_cache_lock:
+        cached = _azure_db_cache.get(cache_key)
+        if cached is not None and cached.is_file():
+            return cached
+        root = (
+            temp_root
+            if temp_root is not None
+            else Path(tempfile.gettempdir()) / "subtitle-generator"
+        )
+        root.mkdir(parents=True, exist_ok=True)
+        destination = root / (
+            f"{source.stem}-{stat.st_mtime_ns:x}-{stat.st_size:x}{source.suffix}"
+        )
+        if not destination.is_file():
+            staging = destination.with_suffix(
+                f"{destination.suffix}.{os.getpid()}.tmp"
+            )
+            try:
+                shutil.copyfile(source, staging)
+                os.replace(staging, destination)
+            finally:
+                if staging.exists():
+                    staging.unlink()
+        _azure_db_cache.clear()
+        _azure_db_cache[cache_key] = destination
+        return destination
 
 
 def parse_tone(tone_str: str | None) -> set[str] | None:

--- a/tests/test_pipeline_characterization.py
+++ b/tests/test_pipeline_characterization.py
@@ -1286,16 +1286,30 @@ def test_handler_resolves_relative_db_path_from_package_root(
 def test_handler_opens_azure_packaged_db_read_only(tmp_path, monkeypatch):
     from subtitle_generator import handlers
 
-    db_path = tmp_path / "subtitles.mini.db"
+    package_root = tmp_path / "package"
+    db_path = package_root / "data" / "subtitles.mini.db"
+    db_path.parent.mkdir(parents=True)
     conn = sqlite3.connect(db_path)
     conn.execute("CREATE TABLE config (key TEXT PRIMARY KEY, value TEXT)")
     conn.commit()
     conn.close()
     monkeypatch.setenv("SUBTITLE_GEN_MODE", "azure")
+    runtime_root = tmp_path / "runtime"
+    monkeypatch.setattr(
+        handlers.tempfile,
+        "gettempdir",
+        lambda: str(runtime_root),
+    )
+    handlers._azure_db_cache.clear()
 
     packaged = handlers.get_db(str(db_path))
     try:
         assert packaged.execute("SELECT COUNT(*) FROM config").fetchone()[0] == 0
+        opened_path = Path(
+            packaged.execute("PRAGMA database_list").fetchone()[2]
+        ).resolve()
+        assert opened_path.parent == runtime_root / "subtitle-generator"
+        assert opened_path.read_bytes() == db_path.read_bytes()
         with pytest.raises(sqlite3.OperationalError, match="readonly"):
             packaged.execute("INSERT INTO config VALUES ('x', 'y')")
     finally:


### PR DESCRIPTION
## Summary

- copy the packaged mini DB once per Azure worker into writable temporary storage
- cache the copied path by packaged source signature
- open the temporary copy read-only and immutable
- keep local serving/writable rating behavior unchanged

## Production failure

The prior hotfix restored Function startup and health, but generation still returned `unable to open database file`. Package inspection confirmed `data/subtitles.mini.db` is present. Azure Flex mounts the released package in a way that prevents SQLite from opening the packaged file directly, even read-only.

## Validation

- regression verifies the DB is copied under the worker temp directory
- copied bytes match the packaged source
- reads work and writes fail read-only
- relative package-root path test passes
- ruff clean
- ty clean

The deployment smoke test will verify health and generation in the real Flex environment.