### PR TITLE
fix: make deployed mini DB worker-readable

### DIFF
--- a/src/subtitle_generator/export_db.py
+++ b/src/subtitle_generator/export_db.py
@@ -313,6 +313,7 @@ def build_mini_db(data_dir: Path, output_path: Path) -> dict:
         conn.execute("VACUUM")
         conn.close()
         conn = None
+        os.chmod(temp_path, 0o644)
         os.replace(temp_path, output_path)
         return stats
     except Exception:

--- a/tests/test_shadow_runtime.py
+++ b/tests/test_shadow_runtime.py
@@ -2,6 +2,7 @@
 
 import json
 import math
+import os
 import random
 import sqlite3
 import subprocess
@@ -1047,7 +1048,10 @@ def test_build_mini_db_preserves_existing_output_on_invalid_shadow_import(tmp_pa
     assert list(tmp_path.glob("mini-*.tmp.db")) == []
 
 
-def test_build_mini_db_replaces_existing_output_atomically_on_success(tmp_path):
+def test_build_mini_db_replaces_existing_output_atomically_on_success(
+    tmp_path,
+    monkeypatch,
+):
     conn = _make_shadow_runtime_db(tmp_path / "runtime.db")
     data_dir = tmp_path / "data"
     export_data(conn, data_dir)
@@ -1058,6 +1062,17 @@ def test_build_mini_db_replaces_existing_output_atomically_on_success(tmp_path):
     )
     mini_db_path = tmp_path / "mini.db"
     mini_db_path.write_bytes(b"stale-mini-db")
+    chmod_calls = []
+    real_chmod = os.chmod
+
+    def recording_chmod(path, mode):
+        chmod_calls.append((Path(path), mode))
+        real_chmod(path, mode)
+
+    monkeypatch.setattr(
+        "subtitle_generator.export_db.os.chmod",
+        recording_chmod,
+    )
 
     build_stats = build_mini_db(data_dir, mini_db_path)
     rebuilt = sqlite3.connect(mini_db_path)
@@ -1071,6 +1086,7 @@ def test_build_mini_db_replaces_existing_output_atomically_on_success(tmp_path):
     assert mini_db_path.read_bytes() != b"stale-mini-db"
     assert build_stats[TIER_SLOT_FILLER_DISTRIBUTION_TABLE] == len(shadow_rows)
     assert shadow_count == len(shadow_rows)
+    assert chmod_calls and chmod_calls[-1][1] == 0o644
 
 
 def test_build_mini_db_rejects_artifact_default_without_distribution(tmp_path):


### PR DESCRIPTION
## Summary

- set the atomically built mini SQLite DB to Unix mode `0644` before replacing the output
- add a regression assertion that the builder applies worker-readable permissions

## Production root cause

Package inspection showed:

- `function_app.py`: `0644`
- `subtitle_generator/handlers.py`: `0644`
- `data/subtitles.mini.db`: **`0600`**

`build_mini_db` uses `NamedTemporaryFile`, whose private mode survived `os.replace`. Azure Flex serves the package to a worker identity that cannot read the owner-only DB, causing `Permission denied` and generation 500s.

## Validation

- atomic mini-DB replacement test passes and verifies `chmod(..., 0o644)`
- ruff clean
- ty clean

The deployment workflow rebuilds the mini DB, so the next package should contain a readable `0644` database and rerun health/generation smoke tests.