### PR TITLE
docs: describe anchored runtime pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> Created/edited by GitHub Copilot with human review/feedback by Avi Levin.
+
 # subtitle-generator
 
 Generate strange pop-nonfiction subtitles in the pattern:
@@ -10,15 +12,20 @@ The project mines real book titles and subtitles from Library of Congress and Op
 
 ## Current runtime model
 
-Generation now separates two concerns:
+Generation now separates these responsibilities:
 
 | Concern | Runtime behavior |
 |---|---|
-| **Categorization** | Learned book-model probabilities classify each existing slot filler as pop, mainstream, or niche. |
-| **Generation** | The generator still samples from the same validated filler universe; requested tone tiers weight fillers by the learned probability for that tier. |
+| **Build evidence** | Source labels, learned book-model probabilities, confidence, and priors contribute evidence to the tier-slot artifact. |
+| **Generation** | The default runtime samples directly from normalized `P(filler | tier, slot_type)` over the validated filler universe. |
+| **Rollback** | The former `sqrt(freq) * score_T` path remains available explicitly as `legacy`. |
 | **Guardrail** | A narrow literal-artifact filter removes broken strings and malformed final objects without rejecting funny conceptual collisions. |
 
-The deployment inputs include tracked CSVs such as `api\data\slot_filler_model_scores.csv`. The ignored mini DB at `api\data\subtitles.mini.db` is built from those CSVs locally and in CI, so deployed Azure Functions do not need the full local SQLite database.
+The deployment inputs include the tracked
+`api\data\tier_slot_filler_distribution_v1.csv` artifact and
+`generation_runtime_mode=artifact` config. The ignored mini DB at
+`api\data\subtitles.mini.db` is built from tracked CSVs locally and in CI, so
+deployed Azure Functions do not need the full local SQLite database.
 
 ## Examples
 
@@ -61,6 +68,7 @@ uv run subtitle-gen generate
 uv run subtitle-gen generate --tone pop
 uv run subtitle-gen generate --tone mainstream --sources
 uv run subtitle-gen generate --tone niche --jacket
+uv run subtitle-gen generate --runtime legacy --tone pop  # rollback comparison
 uv run subtitle-gen jacket "sturgeon, caviar, and the geography of desire"
 uv run subtitle-gen serve --no-open
 ```
@@ -85,9 +93,11 @@ uv run subtitle-gen validate-pipeline
 
 The pipeline stages are contract-checked. `validate-pipeline` is read-only and verifies schema, config, remix precompute state, popularity coverage, model IDs, and serving readiness.
 
-## Book-model tiering workflow
+## Book-model evidence workflow
 
-The learned runtime categorizer is produced offline, then installed as slot-filler probabilities.
+The offline book model produces filler-level tier evidence. Those scores feed the
+anchored tier-slot artifact and remain installed for legacy rollback and
+compatibility classification.
 
 ```powershell
 uv sync --extra ml --extra tune
@@ -115,7 +125,7 @@ pwsh -File scripts\run-book-model-pipeline.ps1 -Steps Inventory
 pwsh -File scripts\run-book-model-pipeline.ps1 -Steps Features,Torch,CalibrateRuntimeTierModel,Distill,Shadow,CategorizationGate -PlanOnly
 ```
 
-The runtime table is `slot_filler_model_scores`:
+The evidence/rollback table is `slot_filler_model_scores`:
 
 | Column | Meaning |
 |---|---|
@@ -126,7 +136,9 @@ The runtime table is `slot_filler_model_scores`:
 | `model_tier` | Highest-scoring learned tier. |
 | `source_prediction_count` | Number of source-book predictions that contributed to the rollup. |
 
-Mini DB builds reject partial model-score coverage when `slot_filler_model_scores.csv` is present. This keeps deployment from silently mixing learned-tier and legacy sampling scales.
+Mini DB builds reject partial model-score coverage when
+`slot_filler_model_scores.csv` is present. This keeps artifact rebuilds and
+legacy rollback from silently using partially scored fillers.
 
 ## Export and deployment artifacts
 
@@ -155,12 +167,16 @@ Ignored build outputs:
 
 | Path | Purpose |
 |---|---|
-| `api\data\subtitles.mini.db` | Built SQLite artifact used by local serving and Azure Functions; CI rebuilds it from CSVs. |
+| `api\data\subtitles.mini.db` | Built SQLite artifact used by local serving and Azure Functions; CI rebuilds it from CSVs with worker-readable permissions. |
 | `generated-artifacts\` | Local reports, model features, predictions, rollups, and gate outputs. |
 
 The configured default runtime is `artifact`. Use `--runtime legacy`,
 `SUBTITLE_GEN_RUNTIME_MODE=legacy`, or
 `subtitle-gen set-runtime-default --mode legacy` to roll back.
+
+Azure Flex mounts the released package read-only. The Function worker copies the
+packaged mini DB once into temporary storage and opens that immutable copy
+read-only; local serving continues to use its writable DB for local ratings.
 
 ## Local verification
 

--- a/docs/pipeline-end-to-end.md
+++ b/docs/pipeline-end-to-end.md
@@ -46,7 +46,7 @@ generator weights existing strict fillers for a requested tier.
 
 ## 0. Runtime contract
 
-The deployed generator has four responsibilities:
+The deployed generator has five responsibilities:
 
 | Responsibility | Runtime state | Effect |
 |---|---|---|
@@ -492,7 +492,8 @@ the rich teacher using only durable/export-safe features.
 | `export-current` | title/subtitle text plus basic source shape | 261 | 1,895 | 4,537 | 95.8% |
 | `export-slot` | `export-current` plus slot aggregate scalars such as source-link count, distinct strict filler count, max filler popularity, and average filler popularity | 392 | 2,071 | 4,230 | 87.4% |
 
-`export-slot` is the selected runtime source. It agrees less tightly with the
+`export-slot` is the selected source for tier-slot evidence and legacy rollback.
+It agrees less tightly with the
 teacher than `export-current`, but its slot aggregate features move the export
 toward a broader pop/mainstream pool. That is desirable for generation because
 the deployed scores are sampling weights over strict fillers, not final claims
@@ -744,7 +745,7 @@ Ignored local/CI-built artifacts:
 
 | Path | Purpose |
 |---|---|
-| `api\data\subtitles.mini.db` | Built SQLite artifact for local serving and Azure Functions; CI rebuilds it from tracked CSVs. |
+| `api\data\subtitles.mini.db` | Built SQLite artifact for local serving and Azure Functions; CI rebuilds it from tracked CSVs with mode `0644`. |
 | `generated-artifacts\` | Local reports, features, predictions, rollups, and gate outputs. |
 
 If `slot_filler_model_scores.csv` exists, `build-db` requires one score row for
@@ -752,6 +753,12 @@ every exported slot filler. Partial coverage is rejected so deployment cannot
 mix learned-tier rollback sampling with unscored filler choices. When
 `generation_runtime_mode=artifact`, `build-db` also requires and validates the
 tier-slot distribution CSV.
+
+Azure Flex mounts the deployment package read-only. At worker startup,
+`handlers.py` copies the packaged mini DB once to the worker temporary directory,
+keys that copy by source signature, and opens it with SQLite
+`mode=ro&immutable=1`. This avoids package-mount journal/permission failures.
+Local serving keeps normal writable SQLite behavior for local rating storage.
 
 ## 16. Repeat the book-model path with the runner
 


### PR DESCRIPTION
## Summary

- update the README’s current runtime model from filler-score weighting to anchored `P(filler | tier, slot_type)` sampling
- clarify that book-model scores are build evidence and legacy rollback state
- document the tracked tier-slot deployment artifact and rollback commands
- document mini-DB worker-readable permissions and Azure Flex temporary DB materialization
- correct the end-to-end runner and deployment sequence

Documentation only; no runtime behavior changes.